### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@
 //!
 //! [chain (tree) of responsibility]: https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern
 
+#![feature(closure_track_caller)]
+
 mod handler;
 
 pub mod di;


### PR DESCRIPTION
Interesting fact

When you are building teloxide on raspberry pi on nightly branch it says:

```
 error[E0658]: `#[track_caller]` on closures is currently unstable
  --> /home/pi/.cargo/registry/src/github.com-1285ae84e5963aae/dptree-0.3.0/src/handler/endpoint.rs:23:20
   |
23 |           async move {
   |  ____________________^
24 | |             let f = f.inject(&x);
25 | |             f().map(ControlFlow::Break).await
26 | |         }
   | |_________^
   |
   = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
   = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
```

I cannot reproduce it anywhere else and cannot explain why it happens but I figured out how to fix it.
