### PR TITLE
Implement "startup-time" type checking 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+
+ - The `type_check` function that performs run-time type checking. Call this function to ensure that all types required by your handler are present in `DependencyMap`.
+ - The `HandlerRtSig` and `RtType` types.
+ - The `Handler::sig` function.
+ - The `Injectable::input_types` associated function [**BC**].
+
+### Changed
+
+ - The `Output` generic of `Injectable` is now required to be `'static` [**BC**].
+ - Function parameters in the implementation of `Injectable` for functions are now required to be `'static` [**BC**].
+ - `Handler::{chain, branch}` now panic if the second handler is `dptree::entry()` [**BC**].
+ - The following functions now accept the `sig: HandlerRtSig` parameter [**BC**]:
+   - `dptree::from_fn`
+   - `dptree::from_fn_with_description`
+
 ## 0.3.0 - 2022-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - The `type_check` function that performs run-time type checking. Call this function to ensure that all types required by your handler are present in `DependencyMap`.
- - The `HandlerRtSig` and `RtType` types.
+ - The `type_check` function that performs run-time type checking. Call this function to ensure that all types required by your handler are present in `di::DependencyMap`.
+ - The `HandlerSignature` and `Type` types.
  - The `Handler::sig` function.
- - The `Injectable::input_types` associated function [**BC**].
+ - The `di::Injectable::input_types` associated function [**BC**].
 
 ### Changed
 
- - The `Output` generic of `Injectable` is now required to be `'static` [**BC**].
- - Function parameters in the implementation of `Injectable` for functions are now required to be `'static` [**BC**].
+ - The `Output` generic of `di::Injectable` is now required to be `'static` [**BC**].
+ - Function parameters in the implementation of `di::Injectable` for functions are now required to be `'static` [**BC**].
  - `Handler::{chain, branch}` now panic if the second handler is `dptree::entry()` [**BC**].
- - The following functions now accept the `sig: HandlerRtSig` parameter [**BC**]:
-   - `dptree::from_fn`
-   - `dptree::from_fn_with_description`
- - Always use `DependencyMap` instead of a generic `Input` type.
+ - The following functions now accept the `sig: HandlerSignature` parameter [**BC**]:
+   - `from_fn`
+   - `from_fn_with_description`
+ - Always use `di::DependencyMap` instead of a generic `Input` type.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - The following functions now accept the `sig: HandlerRtSig` parameter [**BC**]:
    - `dptree::from_fn`
    - `dptree::from_fn_with_description`
+ - Always use `DependencyMap` instead of a generic `Input` type.
+
+### Removed
+
+ - The `di::{Insert, DependencySupplier}` traits.
 
 ## 0.3.0 - 2022-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dptree"
 version = "0.3.0"
-authors = ["p0lunin <dmytro.polunin@gmail.com>", "Hirrolot <hirrolot@gmail.com>"]
+authors = ["p0lunin <dmytro.polunin@gmail.com>", "hirrolot <hirrolot@gmail.com>"]
 edition = "2018"
 description = "An asynchronous event dispatch mechanism for Rust"
 repository = "https://github.com/teloxide/dptree"
@@ -14,10 +14,10 @@ license = "MIT"
 
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+rustc-hash = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
-maplit = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ license = "MIT"
 
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
-rustc-hash = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
+maplit = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync"] }
-maplit = "1.0.2"
+maplit = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An implementation of the [chain (tree) of responsibility] pattern.
 ```rust
 use dptree::prelude::*;
 
-type WebHandler = Endpoint<'static, DependencyMap, String>;
+type WebHandler = Endpoint<'static, String>;
 
 #[rustfmt::skip]
 #[tokio::main]

--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ fn not_found_handler() -> WebHandler {
 ## Features
 
  - ✔️ Declarative handlers: `dptree::{endpoint, filter, filter_map, ...}`.
- - ✔️ A lightweight functional design using a form of [continuation-passing style (CPS)] internally.
+ - ✔️ A lightweight functional design without typical OOP hodgepodge.
  - ✔️ [Dependency injection (DI)] out-of-the-box.
- - ✔️ Supports both handler _chaining_ and _branching_ operations.
+ - ✔️ Startup-time [type checking] of run-time dependencies via `dptree::type_check`.
  - ✔️ Handler introspection facilities.
- - ✔️ Battle-tested: dptree is used in [teloxide] as a framework for Telegram update dispatching.
- - ✔️ Runtime-agnostic: uses only the [futures] crate.
+ - ✔️ Battle-tested: dptree is used in [`teloxide`] as a framework for Telegram update dispatching.
+ - ✔️ Runtime-agnostic: uses only the [`futures`] crate.
 
-[continuation-passing style (CPS)]: https://en.wikipedia.org/wiki/Continuation-passing_style
 [Dependency injection (DI)]: https://en.wikipedia.org/wiki/Dependency_injection
-[teloxide]: https://github.com/teloxide/teloxide
-[futures]: https://github.com/rust-lang/futures-rs
+[type checking]: https://github.com/teloxide/dptree/blob/master/examples/diagnostics.rs
+[`teloxide`]: https://github.com/teloxide/teloxide
+[`futures`]: https://github.com/rust-lang/futures-rs
 
 ## Explanation
 
@@ -100,13 +100,12 @@ We decided to use a [continuation-passing style (CPS)] internally and expose nea
 
 ### DI
 
-In Rust, it is possible to express type-safe DI that checks all types statically. However, this would require complex type-level manipulations (like those in the [frunk] library). [@p0lunin] and I ([@Hirrolot]) decided not to trade comprehensible error messages for compile-time safety, since we had a plenty of experience that the uninitiated users simply cannot understand what is wrong with their code, owing to the utterly inadequate diagnostic messages from rustc.
+In Rust, it is possible to express type-safe DI that checks all types statically. However, this would require complex type-level manipulations, such as those in the [`frunk`] library. We decided not to trade comprehensible error messages for compile-time safety, since we had a plenty of experience that the uninitiated users simply cannot understand what is wrong with their code, owing to the utterly inadequate diagnostic messages from rustc.
 
-The approach taken by `dptree` is to implement run-time type checking instead, via `dptree::type_check`, to make sure that all required types are provided _before_ execution. If `dptree::type_check` is _not_ called, type checking will be delayed until execution (this is not recommended). This approach works much like static type checking when you build your whole dispatch tree at a program startup; the downside is that the panic message raised by `dptree::type_check` does not show the exact location to be fixed, only a final type mismatch message (the types in question are shown though!).
+The approach taken by `dptree` is to implement run-time type checking instead, via `dptree::type_check`, to make sure that all required types are provided _before_ execution. If `dptree::type_check` is _not_ called, type checking will be delayed until execution (this is not recommended). This approach works much like static type checking when you build your whole dispatch tree at a program startup; the panic message raised by `dptree::type_check` even [shows the exact locations] in user code that require insatisfied dependencies!
 
-[frunk]: https://github.com/lloydmeta/frunk
-[@p0lunin]: https://github.com/p0lunin
-[@Hirrolot]: https://github.com/Hirrolot
+[shows the exact locations]: https://github.com/teloxide/dptree/blob/master/examples/diagnostics.rs
+[`frunk`]: https://github.com/lloydmeta/frunk
 
 ## Troubleshooting
 

--- a/examples/descr_locations.rs
+++ b/examples/descr_locations.rs
@@ -1,6 +1,6 @@
 use std::panic::Location;
 
-use dptree::{di::DependencyMap, Handler, HandlerDescription};
+use dptree::{Handler, HandlerDescription};
 
 struct CollectLocations {
     locations: Vec<(&'static str, &'static Location<'static>)>,
@@ -85,14 +85,14 @@ impl HandlerDescription for CollectLocations {
 }
 
 fn get_locations<'a, 'b>(
-    handler: &'a Handler<'b, impl Send + Sync + 'b, impl Send + Sync + 'b, CollectLocations>,
+    handler: &'a Handler<'b, impl Send + Sync + 'b, CollectLocations>,
 ) -> &'a [(&'static str, &'static Location<'static>)] {
     &handler.description().locations
 }
 
 fn main() {
     #[rustfmt::skip]
-    let some_tree: Handler<DependencyMap, _, _> = dptree::entry()
+    let some_tree: Handler< _, _> = dptree::entry()
         .branch(
             dptree::filter(|| true)
                 .endpoint(|| async {})

--- a/examples/diagnostics.rs
+++ b/examples/diagnostics.rs
@@ -17,14 +17,13 @@ async fn main() {
     dptree::type_check(h.sig(), &dptree::deps![B, D]);
 }
 
-// thread 'main' panicked at 'This handler accepts the following types:
+// thread 'main' panicked at src/handler/core.rs:549:17:
+// This handler accepts the following types:
 //     diagnostics::A
 //     diagnostics::C
 // , but only the following types are provided:
-//     diagnostics::D
 //     diagnostics::B
+//     diagnostics::D
 // The missing types are:
-//     diagnostics::A from examples/diagnostics.rs:15:25
-//     diagnostics::C from examples/diagnostics.rs:15:39',
-// src/handler/core.rs:551:17 note: run with `RUST_BACKTRACE=1` environment
-// variable to display a backtrace
+//     diagnostics::A from examples/diagnostics.rs:14:41
+//     diagnostics::C from examples/diagnostics.rs:14:55

--- a/examples/diagnostics.rs
+++ b/examples/diagnostics.rs
@@ -1,0 +1,31 @@
+use dptree::prelude::*;
+
+#[derive(Clone)]
+struct A;
+#[derive(Clone)]
+struct B;
+#[derive(Clone)]
+struct C;
+#[derive(Clone)]
+struct D;
+
+#[tokio::main]
+async fn main() {
+    let h: Handler<DependencyMap, D> =
+        dptree::entry().map(|_: A| B).inspect(|_: C| ()).endpoint(|| async { D });
+
+    // Missing `A` and `C` in the dependency map (see the panic message below).
+    dptree::type_check(h.sig(), &dptree::deps![B, D]);
+}
+
+// thread 'main' panicked at 'This handler accepts the following types:
+//     diagnostics::A
+//     diagnostics::C
+// , but only the following types are provided:
+//     diagnostics::D
+//     diagnostics::B
+// The missing types are:
+//     diagnostics::A from examples/diagnostics.rs:15:25
+//     diagnostics::C from examples/diagnostics.rs:15:39',
+// src/handler/core.rs:551:17 note: run with `RUST_BACKTRACE=1` environment
+// variable to display a backtrace

--- a/examples/diagnostics.rs
+++ b/examples/diagnostics.rs
@@ -11,8 +11,7 @@ struct D;
 
 #[tokio::main]
 async fn main() {
-    let h: Handler<DependencyMap, D> =
-        dptree::entry().map(|_: A| B).inspect(|_: C| ()).endpoint(|| async { D });
+    let h: Handler<D> = dptree::entry().map(|_: A| B).inspect(|_: C| ()).endpoint(|| async { D });
 
     // Missing `A` and `C` in the dependency map (see the panic message below).
     dptree::type_check(h.sig(), &dptree::deps![B, D]);

--- a/examples/simple_dispatcher.rs
+++ b/examples/simple_dispatcher.rs
@@ -39,7 +39,7 @@ async fn main() {
     repl(dispatcher, store).await
 }
 
-async fn repl(dispatcher: Handler<'static, DependencyMap, String>, store: Arc<AtomicI32>) -> ! {
+async fn repl(dispatcher: Handler<'static, String>, store: Arc<AtomicI32>) -> ! {
     loop {
         print!(">> ");
         std::io::stdout().flush().unwrap();
@@ -80,7 +80,7 @@ impl Event {
     }
 }
 
-type CommandHandler = Endpoint<'static, DependencyMap, String>;
+type CommandHandler = Endpoint<'static, String>;
 
 fn ping_handler() -> CommandHandler {
     dptree::filter_async(|event: Event| async move { matches!(event, Event::Ping) })

--- a/examples/state_machine.rs
+++ b/examples/state_machine.rs
@@ -21,7 +21,7 @@ async fn main() {
     repl(state, dispatcher).await
 }
 
-async fn repl(mut state: CommandState, dispatcher: Handler<'static, Store, CommandState>) {
+async fn repl(mut state: CommandState, dispatcher: Handler<'static, CommandState>) {
     loop {
         println!("|| Current state is {}", state);
         print!(">> ");
@@ -96,8 +96,7 @@ impl Event {
     }
 }
 
-type Store = dptree::di::DependencyMap;
-type Transition = Endpoint<'static, Store, TransitionOut>;
+type Transition = Endpoint<'static, TransitionOut>;
 type TransitionOut = CommandState;
 
 mod transitions {
@@ -124,7 +123,7 @@ mod transitions {
     }
 }
 
-type FsmHandler = Handler<'static, Store, TransitionOut>;
+type FsmHandler = Handler<'static, TransitionOut>;
 
 fn active_handler() -> FsmHandler {
     dptree::case![CommandState::Active].branch(transitions::pause()).branch(transitions::end())

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,34 +1,32 @@
 use dptree::prelude::*;
-use std::{net::Ipv4Addr, sync::Arc};
+use std::net::Ipv4Addr;
 
-type Store = Arc<DependencyMap>;
+fn assert_num_string_handler(
+    expected_num: u32,
+    expected_string: &'static str,
+) -> Endpoint<'static, ()> {
+    // The handler requires `u32` and `String` types from the input storage.
+    dptree::endpoint(move |num: u32, string: String| async move {
+        assert_eq!(num, expected_num);
+        assert_eq!(string, expected_string);
+    })
+}
 
 #[tokio::main]
 async fn main() {
-    fn assert_num_string_handler(
-        expected_num: u32,
-        expected_string: &'static str,
-    ) -> Endpoint<'static, Store, ()> {
-        // The handler requires `u32` and `String` types from the input storage.
-        dptree::endpoint(move |num: u32, string: String| async move {
-            assert_eq!(num, expected_num);
-            assert_eq!(string, expected_string);
-        })
-    }
+    // Init the storage with `u32` and `String` values.
+    let store = dptree::deps![10u32, "Hello".to_owned()];
 
-    // Init storage with string and num
-    let store = Arc::new(dptree::deps![10u32, "Hello".to_owned()]);
+    let h = assert_num_string_handler(10u32, "Hello");
 
-    let str_num_handler = assert_num_string_handler(10u32, "Hello");
-
-    str_num_handler.dispatch(store.clone()).await;
+    h.dispatch(store.clone()).await;
 
     // This will cause a panic because we do not store `Ipv4Addr` in out store.
     let handle = tokio::spawn(async move {
-        let ip_handler: Endpoint<_, _> = dptree::endpoint(|ip: Ipv4Addr| async move {
+        let ip_handler: Endpoint<_> = dptree::endpoint(|ip: Ipv4Addr| async move {
             assert_eq!(ip, Ipv4Addr::new(0, 0, 0, 0));
         });
-        ip_handler.dispatch(store.clone()).await;
+        ip_handler.dispatch(store).await;
     });
     let result = handle.await;
     assert!(result.is_err())

--- a/examples/web_server.rs
+++ b/examples/web_server.rs
@@ -1,6 +1,6 @@
 use dptree::prelude::*;
 
-type WebHandler = Endpoint<'static, DependencyMap, String>;
+type WebHandler = Endpoint<'static, String>;
 
 #[rustfmt::skip]
 #[tokio::main]

--- a/src/di.rs
+++ b/src/di.rs
@@ -20,6 +20,7 @@ use std::{
     fmt::{Debug, Formatter, Write},
     future::Future,
     ops::Deref,
+    panic::Location,
     sync::Arc,
 };
 
@@ -205,6 +206,18 @@ where
     /// Returns the set of types that this function depends on. Used only for
     /// run-time "type checking".
     fn input_types() -> HashSet<Type>;
+
+    /// Returns the map of obligations of this function.
+    ///
+    /// The map contains all types from [`Self::input_types`] as keys, each one
+    /// corresponding to the current [`Location::caller`].
+    ///
+    /// [`Location::caller`]: std::panic::Location::caller
+    #[track_caller]
+    fn obligations() -> HashMap<Type, &'static Location<'static>> {
+        let location = Location::caller();
+        Self::input_types().into_iter().map(|ty| (ty, location)).collect()
+    }
 }
 
 /// A function with all dependencies satisfied.

--- a/src/di.rs
+++ b/src/di.rs
@@ -12,13 +12,15 @@
 //!
 //! [dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
 //! [this discussion on StackOverflow]: https://stackoverflow.com/questions/130794/what-is-dependency-injection
+
 use futures::future::{ready, BoxFuture};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use std::{
     any::{Any, TypeId},
-    collections::{HashMap, HashSet},
     fmt::{Debug, Formatter, Write},
     future::Future,
+    iter::FromIterator,
     panic::Location,
     sync::Arc,
 };
@@ -73,7 +75,7 @@ use crate::Type;
 /// ```
 #[derive(Default, Clone)]
 pub struct DependencyMap {
-    pub(crate) map: HashMap<TypeId, Dependency>,
+    pub(crate) map: FxHashMap<TypeId, Dependency>,
 }
 
 #[derive(Clone)]
@@ -176,7 +178,7 @@ where
 
     /// Returns the set of types that this function depends on. Used only for
     /// run-time "type checking".
-    fn input_types() -> HashSet<Type>;
+    fn input_types() -> FxHashSet<Type>;
 
     /// Returns the map of obligations of this function.
     ///
@@ -185,7 +187,7 @@ where
     ///
     /// [`Location::caller`]: std::panic::Location::caller
     #[track_caller]
-    fn obligations() -> HashMap<Type, &'static Location<'static>> {
+    fn obligations() -> FxHashMap<Type, &'static Location<'static>> {
         let location = Location::caller();
         Self::input_types().into_iter().map(|ty| (ty, location)).collect()
     }
@@ -216,8 +218,8 @@ macro_rules! impl_into_di {
                 })
             }
 
-            fn input_types() -> HashSet<Type> {
-                HashSet::from([
+            fn input_types() -> FxHashSet<Type> {
+                FxHashSet::from_iter(vec![
                     $(Type::of::<$generic>()),*
                 ])
             }
@@ -240,8 +242,8 @@ macro_rules! impl_into_di {
                 })
             }
 
-            fn input_types() -> HashSet<Type> {
-                HashSet::from([
+            fn input_types() -> FxHashSet<Type> {
+                FxHashSet::from_iter(vec![
                     $(Type::of::<$generic>()),*
                 ])
             }

--- a/src/di.rs
+++ b/src/di.rs
@@ -66,10 +66,10 @@ use crate::Type;
 /// container.insert(true);
 /// container.insert("static str");
 ///
-/// // alloc::string::String was requested, but not provided. Available types:
-/// //     i32
-/// //     &str
-/// //     bool
+/// // `alloc::string::String` was requested, but not provided. Available types:
+/// //     `i32`
+/// //     `&str`
+/// //     `bool`
 /// let string: Arc<String> = container.get();
 /// ```
 #[derive(Default, Clone, Debug)]
@@ -143,7 +143,7 @@ impl DependencyMap {
             .get(&TypeId::of::<V>())
             .unwrap_or_else(|| {
                 panic!(
-                    "{} was requested, but not provided. Available types:\n{}",
+                    "`{}` was requested, but not provided. Available types:\n{}",
                     std::any::type_name::<V>(),
                     self.available_types()
                 )
@@ -158,7 +158,7 @@ impl DependencyMap {
         let mut list = String::new();
 
         for dep in self.map.values() {
-            writeln!(list, "    {}", dep.type_name).unwrap();
+            writeln!(list, "    `{}`", dep.type_name).unwrap();
         }
 
         list

--- a/src/di.rs
+++ b/src/di.rs
@@ -14,10 +14,10 @@
 //! [this discussion on StackOverflow]: https://stackoverflow.com/questions/130794/what-is-dependency-injection
 
 use futures::future::{ready, BoxFuture};
-use rustc_hash::{FxHashMap, FxHashSet};
 
 use std::{
     any::{Any, TypeId},
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter, Write},
     future::Future,
     iter::FromIterator,
@@ -38,8 +38,8 @@ use crate::Type;
 /// # Examples
 ///
 /// ```
-/// # use std::sync::Arc;
 /// use dptree::di::DependencyMap;
+/// use std::sync::Arc;
 ///
 /// let mut container = DependencyMap::new();
 /// container.insert(5_i32);
@@ -58,24 +58,23 @@ use crate::Type;
 /// When a value is not found within the container, it will panic:
 ///
 /// ```should_panic
-/// # use std::sync::Arc;
 /// use dptree::di::DependencyMap;
+/// use std::sync::Arc;
+///
 /// let mut container = DependencyMap::new();
 /// container.insert(10i32);
 /// container.insert(true);
 /// container.insert("static str");
 ///
-/// // thread 'main' panicked at 'alloc::string::String was requested, but not provided. Available types:
-/// //    &str
-/// //    bool
-/// //    i32
-/// // ', /media/hirrolot/772CF8924BEBB279/Documents/Rust/dptree/src/di.rs:150:17
-/// // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+/// // alloc::string::String was requested, but not provided. Available types:
+/// //     i32
+/// //     &str
+/// //     bool
 /// let string: Arc<String> = container.get();
 /// ```
 #[derive(Default, Clone, Debug)]
 pub struct DependencyMap {
-    pub(crate) map: FxHashMap<TypeId, Dependency>,
+    pub(crate) map: BTreeMap<TypeId, Dependency>,
 }
 
 #[derive(Clone)]
@@ -178,7 +177,7 @@ where
 
     /// Returns the set of types that this function depends on. Used only for
     /// run-time "type checking".
-    fn input_types() -> FxHashSet<Type>;
+    fn input_types() -> BTreeSet<Type>;
 
     /// Returns the map of obligations of this function.
     ///
@@ -187,7 +186,7 @@ where
     ///
     /// [`Location::caller`]: std::panic::Location::caller
     #[track_caller]
-    fn obligations() -> FxHashMap<Type, &'static Location<'static>> {
+    fn obligations() -> BTreeMap<Type, &'static Location<'static>> {
         let location = Location::caller();
         Self::input_types().into_iter().map(|ty| (ty, location)).collect()
     }
@@ -218,8 +217,8 @@ macro_rules! impl_into_di {
                 })
             }
 
-            fn input_types() -> FxHashSet<Type> {
-                FxHashSet::from_iter(vec![
+            fn input_types() -> BTreeSet<Type> {
+                BTreeSet::from_iter(vec![
                     $(Type::of::<$generic>()),*
                 ])
             }
@@ -242,8 +241,8 @@ macro_rules! impl_into_di {
                 })
             }
 
-            fn input_types() -> FxHashSet<Type> {
-                FxHashSet::from_iter(vec![
+            fn input_types() -> BTreeSet<Type> {
+                BTreeSet::from_iter(vec![
                     $(Type::of::<$generic>()),*
                 ])
             }

--- a/src/di.rs
+++ b/src/di.rs
@@ -191,6 +191,7 @@ where
         let location = Location::caller();
         Self::input_types().into_iter().map(|ty| (ty, location)).collect()
     }
+}
 
 /// A function with all dependencies satisfied.
 pub type CompiledFn<'a, Output> = Arc<dyn Fn() -> BoxFuture<'a, Output> + Send + Sync + 'a>;

--- a/src/di.rs
+++ b/src/di.rs
@@ -73,7 +73,7 @@ use crate::Type;
 /// // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 /// let string: Arc<String> = container.get();
 /// ```
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct DependencyMap {
     pub(crate) map: FxHashMap<TypeId, Dependency>,
 }
@@ -82,6 +82,12 @@ pub struct DependencyMap {
 pub(crate) struct Dependency {
     pub(crate) type_name: &'static str,
     inner: Arc<dyn Any + Send + Sync>,
+}
+
+impl Debug for Dependency {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dependency").field("type_name", &self.type_name).finish_non_exhaustive()
+    }
 }
 
 impl PartialEq for DependencyMap {
@@ -157,12 +163,6 @@ impl DependencyMap {
         }
 
         list
-    }
-}
-
-impl Debug for DependencyMap {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        f.debug_struct("DependencyMap").finish()
     }
 }
 

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -59,7 +59,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 /// whether or not to call `c`, but when it is branched, whether `c` is called
 /// depends solely on `a`.
 pub struct Handler<'a, Output, Descr = description::Unspecified> {
-    data: Arc<HandlerData<Descr, DynF<'a, Output>>>,
+    data: Arc<HandlerData<Descr, DynFn<'a, Output>>>,
 }
 
 struct HandlerData<Descr, F: ?Sized> {
@@ -114,7 +114,7 @@ impl PartialEq for Type {
 
 impl Eq for Type {}
 
-type DynF<'a, Output> =
+type DynFn<'a, Output> =
     dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + Send + Sync + 'a;
 
 /// A continuation representing the rest of a handler chain.

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -173,7 +173,9 @@ where
             (_, HandlerSignature::Entry) => {
                 panic!("Ill-typed handler chain: the second handler cannot be an entry")
             }
-            (HandlerSignature::Entry, HandlerSignature::Other { .. }) => next.data.sig.clone(),
+            (HandlerSignature::Entry, other_sig @ HandlerSignature::Other { .. }) => {
+                other_sig.clone()
+            }
             (
                 HandlerSignature::Other {
                     input_types: self_input_types,
@@ -294,7 +296,9 @@ where
             (_, HandlerSignature::Entry) => {
                 panic!("Ill-typed handler branch: the second handler cannot be an entry")
             }
-            (HandlerSignature::Entry, HandlerSignature::Other { .. }) => next.data.sig.clone(),
+            (HandlerSignature::Entry, other_sig @ HandlerSignature::Other { .. }) => {
+                other_sig.clone()
+            }
             (
                 HandlerSignature::Other {
                     input_types: self_input_types,

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -551,8 +551,8 @@ pub fn type_check(sig: &HandlerSignature, container: &DependencyMap) {
                 panic!(
                     "This handler accepts the following types:\n    {}\n, but only the following \
                      types are provided:\n    {}\nThe missing types are:\n    {}",
-                    print_types(obligations.keys(), |ty| ty.name.to_owned()),
-                    print_types(&container_types, |ty| ty.name.to_owned()),
+                    print_types(obligations.keys(), |ty| format!("`{}`", ty.name)),
+                    print_types(&container_types, |ty| format!("`{}`", ty.name)),
                     print_types(
                         obligations.iter().filter_map(|(ty, _location)| {
                             if !container_types.contains(ty) {
@@ -561,7 +561,7 @@ pub fn type_check(sig: &HandlerSignature, container: &DependencyMap) {
                                 None
                             }
                         }),
-                        |ty| { format!("{} from {}", ty.name, obligations[ty]) },
+                        |ty| { format!("`{}` from {}", ty.name, obligations[ty]) },
                     )
                 );
             }
@@ -877,14 +877,14 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "This handler accepts the following types:
-    dptree::handler::core::tests::type_check_panic::A
-    dptree::handler::core::tests::type_check_panic::B
-    dptree::handler::core::tests::type_check_panic::C
+    `dptree::handler::core::tests::type_check_panic::A`
+    `dptree::handler::core::tests::type_check_panic::B`
+    `dptree::handler::core::tests::type_check_panic::C`
 , but only the following types are provided:
-    dptree::handler::core::tests::type_check_panic::A
-    dptree::handler::core::tests::type_check_panic::B
+    `dptree::handler::core::tests::type_check_panic::A`
+    `dptree::handler::core::tests::type_check_panic::B`
 The missing types are:
-    dptree::handler::core::tests::type_check_panic::C from src/handler/core.rs:4:43")]
+    `dptree::handler::core::tests::type_check_panic::C` from src/handler/core.rs:4:43")]
     fn type_check_panic() {
         #[derive(Clone)]
         struct A;

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -1,7 +1,7 @@
 // In order not to break the unit tests if this file is edited, we place this
 // constant right at the beginning.
 #[cfg(test)]
-const FIXED_LOCATION: &'static Location = Location::caller();
+const FIXED_LOCATION: &Location = Location::caller();
 
 use crate::{description, prelude::DependencyMap, HandlerDescription};
 
@@ -592,7 +592,7 @@ mod tests {
         let input = 123;
         let output = "ABC";
 
-        let input_types = vec![Type::of::<i32>()];
+        let input_types = [Type::of::<i32>()];
         let location = Location::caller();
 
         let result = help_inference(from_fn(
@@ -618,7 +618,7 @@ mod tests {
         let input = 123;
         type Output = &'static str;
 
-        let input_types = vec![Type::of::<i32>()];
+        let input_types = [Type::of::<i32>()];
         let location = Location::caller();
 
         let result = help_inference(from_fn(
@@ -654,7 +654,7 @@ mod tests {
         let input = 123;
         let output = "ABC";
 
-        let input_types = vec![Type::of::<i32>()];
+        let input_types = [Type::of::<i32>()];
         let location = Location::caller();
 
         let result = help_inference(from_fn(
@@ -884,7 +884,7 @@ mod tests {
     `dptree::handler::core::tests::type_check_panic::A`
     `dptree::handler::core::tests::type_check_panic::B`
 The missing types are:
-    `dptree::handler::core::tests::type_check_panic::C` from src/handler/core.rs:4:43")]
+    `dptree::handler::core::tests::type_check_panic::C` from src/handler/core.rs:4:35")]
     fn type_check_panic() {
         #[derive(Clone)]
         struct A;
@@ -945,13 +945,8 @@ The missing types are:
                 |_: B, _: D, /* Must propagate. */ _: G| async { H },
             );
 
-        let input_types = vec![
-            Type::of::<A>(),
-            Type::of::<C>(),
-            Type::of::<E>(),
-            Type::of::<F>(),
-            Type::of::<G>(),
-        ];
+        let input_types =
+            [Type::of::<A>(), Type::of::<C>(), Type::of::<E>(), Type::of::<F>(), Type::of::<G>()];
         let outcomes = btreeset! {Type::of::<B>(), Type::of::<D>()};
 
         if let HandlerSignature::Other {

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -102,12 +102,14 @@ pub struct Type {
 }
 
 impl Hash for Type {
+    /// Hashing is done by type identifiers (type names are ignored).
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state);
     }
 }
 
 impl PartialEq for Type {
+    /// Equality is done by type identifiers (type names are ignored).
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -226,7 +226,8 @@ where
                     input_types: self_input_types.union(&next_input_types).cloned().collect(),
 
                     // Since the first handler can call the second one, take the union of their
-                    // output types.
+                    // output types. If the second handler is not called, the dependency map will
+                    // not be touched, so there will be no type errors.
                     output_types: self_output_types.union(next_output_types).cloned().collect(),
 
                     // Take only the most "recent" obligations that occur in user code; the first

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -877,11 +877,9 @@ mod tests {
         #[derive(Clone)]
         struct C;
 
-        let input_types = vec![Type::of::<A>(), Type::of::<B>(), Type::of::<C>()];
-
         type_check(
             &HandlerSignature::Other {
-                input_types: HashSet::from_iter(input_types.iter().cloned()),
+                input_types: HashSet::from([Type::of::<A>(), Type::of::<B>(), Type::of::<C>()]),
                 output_types: hashset! {},
                 obligations: hashmap! { /* Must not be used. */ },
             },

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -5,7 +5,15 @@ const FIXED_LOCATION: &'static Location = Location::caller();
 
 use crate::{description, prelude::DependencyMap, HandlerDescription};
 
-use std::{any::TypeId, fmt::Write, future::Future, ops::ControlFlow, panic::Location, sync::Arc};
+use std::{
+    any::TypeId,
+    fmt::Write,
+    future::Future,
+    hash::{Hash, Hasher},
+    ops::ControlFlow,
+    panic::Location,
+    sync::Arc,
+};
 
 use futures::future::BoxFuture;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -86,7 +94,7 @@ pub enum HandlerSignature {
 /// and checking of handler chains.
 ///
 /// See [`crate::type_check`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug)]
 pub struct Type {
     /// The unique type identifier.
     pub id: TypeId,
@@ -94,6 +102,20 @@ pub struct Type {
     /// The type name used for printing.
     pub name: &'static str,
 }
+
+impl Hash for Type {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for Type {}
 
 type DynF<'a, Output> =
     dyn Fn(DependencyMap, Cont<'a, Output>) -> HandlerResult<'a, Output> + Send + Sync + 'a;

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -120,14 +120,14 @@ impl Eq for Type {}
 impl PartialOrd for Type {
     /// The partial order is done by type names for better diagnostics.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Type {
     /// The total order is done by type names for better diagnostics.
     fn cmp(&self, other: &Self) -> Ordering {
-        self.name.cmp(&other.name)
+        self.name.cmp(other.name)
     }
 }
 
@@ -143,7 +143,7 @@ pub type HandlerResult<'a, Output> = BoxFuture<'a, ControlFlow<Output, Dependenc
 
 // `#[derive(Clone)]` obligates all type parameters to satisfy `Clone` as well,
 // but we do not need it here because of `Arc`.
-impl<'a, Output, Descr> Clone for Handler<'a, Output, Descr> {
+impl<Output, Descr> Clone for Handler<'_, Output, Descr> {
     fn clone(&self) -> Self {
         Handler { data: Arc::clone(&self.data) }
     }
@@ -169,15 +169,15 @@ where
     ///
     /// The algorithm is as follows:
     ///  1. If the second handler's signature is [`HandlerSignature::Entry`],
-    /// then **panic**.
+    ///     then **panic**.
     ///  2. If the first handler's signature is [`HandlerSignature::Entry`] and
-    /// that of the second one is [`HandlerSignature::Other`], then the
-    /// signature of the resulting handler is taken from the second one.
+    ///     that of the second one is [`HandlerSignature::Other`], then the
+    ///     signature of the resulting handler is taken from the second one.
     ///  3. If the first handler's signature is [`HandlerSignature::Other`] and
-    /// that the second one is also [`HandlerSignature::Other`], then the
-    /// signature of the resulting handler is `HandlerSignature::Other {
-    /// obligations: self_obligations UNION (next_obligations DIFFERENCE
-    /// self_outcomes), outcomes: self_outcomes UNION next_outcomes }`.
+    ///     that the second one is also [`HandlerSignature::Other`], then the
+    ///     signature of the resulting handler is `HandlerSignature::Other {
+    ///     obligations: self_obligations UNION (next_obligations DIFFERENCE
+    ///     self_outcomes), outcomes: self_outcomes UNION next_outcomes }`.
     ///
     /// # Examples
     ///
@@ -263,15 +263,15 @@ where
     ///
     /// The algorithm is as follows:
     ///  1. If the second handler's signature is [`HandlerSignature::Entry`],
-    /// then **panic**.
+    ///     then **panic**.
     ///  2. If the first handler's signature is [`HandlerSignature::Entry`] and
-    /// that of the second one is [`HandlerSignature::Other`], then the
-    /// signature of the resulting handler is taken from the second one.
+    ///     that of the second one is [`HandlerSignature::Other`], then the
+    ///     signature of the resulting handler is taken from the second one.
     ///  3. If the first handler's signature is [`HandlerSignature::Other`] and
-    /// that the second one is also [`HandlerSignature::Other`], then the
-    /// signature of the resulting handler is `HandlerSignature::Other {
-    /// obligations: self_obligations UNION next_obligations, outcomes:
-    /// next_outcomes INTERSECTION self_outcomes }`.
+    ///     that the second one is also [`HandlerSignature::Other`], then the
+    ///     signature of the resulting handler is `HandlerSignature::Other {
+    ///     obligations: self_obligations UNION next_obligations, outcomes:
+    ///     next_outcomes INTERSECTION self_outcomes }`.
     ///
     /// # Examples
     ///

--- a/src/handler/core.rs
+++ b/src/handler/core.rs
@@ -1,8 +1,10 @@
-use std::{future::Future, ops::ControlFlow, sync::Arc};
+use std::{
+    any::TypeId, collections::HashSet, fmt::Write, future::Future, ops::ControlFlow, sync::Arc,
+};
 
 use futures::future::BoxFuture;
 
-use crate::{description, HandlerDescription};
+use crate::{description, prelude::DependencyMap, HandlerDescription};
 
 /// An instance that receives an input and decides whether to break a chain or
 /// pass the value further.
@@ -50,7 +52,40 @@ pub struct Handler<'a, Input, Output, Descr = description::Unspecified> {
 
 struct HandlerData<Descr, F: ?Sized> {
     description: Descr,
+    sig: HandlerSignature,
     f: F,
+}
+
+/// A run-time handler signature. Used only for run-time type inference and
+/// checking of handler chains.
+///
+/// See [`crate::type_check`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HandlerSignature {
+    /// The signature corresponding to [`crate::entry`].
+    Entry,
+    /// The handler signature with exact input and output types.
+    Other {
+        /// The set of types that the handler accepts. In the case of a DI
+        /// container, this is the set of types that this handler retrieves from
+        /// the container.
+        input_types: HashSet<Type>,
+        /// The set of types that this handler passes down the chain.
+        output_types: HashSet<Type>,
+    },
+}
+
+/// A run-time representation of a type. Used only for run-time type inference
+/// and checking of handler chains.
+///
+/// See [`crate::type_check`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct Type {
+    /// The unique type identifier.
+    pub id: TypeId,
+
+    /// The type name used for printing.
+    pub name: &'static str,
 }
 
 type DynF<'a, Input, Output> =
@@ -83,6 +118,26 @@ where
     /// chaining and
     /// branching"](#the-difference-between-chaining-and-branching).
     ///
+    /// # Type inference algorithm
+    ///
+    /// This method makes use of [`HandlerSignature`] (stored in every handler)
+    /// to perform run-time type inference of the resulting handler
+    /// signature; this information is used by [`crate::type_check`] to make
+    /// sure that all required types are provided _before_ execution.
+    ///
+    /// The algorithm is as follows:
+    ///  1. If the second handler's signature is [`HandlerSignature::Entry`],
+    /// then **panic**.
+    ///  2. If the first handler's signature is [`HandlerSignature::Entry`] and
+    /// that of the second one is [`HandlerSignature::Other`], then the
+    /// signature of the resulting handler is taken from the second one.
+    ///  3. If the first handler's signature is [`HandlerSignature::Other`] and
+    /// that the second one is also [`HandlerSignature::Other`], then the
+    /// signature of the resulting handler is `HandlerSignature::Other {
+    /// input_types: self_input_types UNION (next_input_types DIFFERENCE
+    /// self_output_types), output_types: self_output_types UNION
+    /// next_output_types }`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -108,12 +163,47 @@ where
     pub fn chain(self, next: Self) -> Self {
         let required_update_kinds_set = self.description().merge_chain(next.description());
 
-        from_fn_with_description(required_update_kinds_set, move |event, cont| {
-            let this = self.clone();
-            let next = next.clone();
+        let new_sig = match (&self.data.sig, &next.data.sig) {
+            (_, HandlerSignature::Entry) => {
+                panic!("Ill-typed handler chain: the second handler cannot be an entry")
+            }
+            (HandlerSignature::Entry, HandlerSignature::Other { .. }) => next.data.sig.clone(),
+            (
+                HandlerSignature::Other {
+                    input_types: self_input_types,
+                    output_types: self_output_types,
+                },
+                HandlerSignature::Other {
+                    input_types: next_input_types,
+                    output_types: next_output_types,
+                },
+            ) => HandlerSignature::Other {
+                /// Since the first handler can call the second one, take the
+                /// union of (the first handler's input types) and (the
+                /// difference between the second handler's input types and the
+                /// first handler's output types). The difference is needed
+                /// because the first handler can pass values to the second one.
+                input_types: self_input_types
+                    .union(&next_input_types.difference(self_output_types).cloned().collect())
+                    .cloned()
+                    .collect(),
 
-            this.execute(event, |event| next.execute(event, cont))
-        })
+                /// Since the first handler can call the second one, take the
+                /// union of their output types.
+                output_types: self_output_types.union(next_output_types).cloned().collect(),
+            },
+        };
+
+        from_fn_with_description(
+            required_update_kinds_set,
+            move |event, cont| {
+                let this = self.clone();
+                let next = next.clone();
+
+                this.execute(event, |event| next.execute(event, cont))
+            },
+            new_sig,
+        )
     }
 
     /// Chain two handlers to make a tree of responsibility.
@@ -121,6 +211,25 @@ where
     /// Chaining is different from branching. See ["The difference between
     /// chaining and
     /// branching"](#the-difference-between-chaining-and-branching).
+    ///
+    /// # Type inference algorithm
+    ///
+    /// This method makes use of [`HandlerSignature`] (stored in every handler)
+    /// to perform run-time type inference of the resulting handler
+    /// signature; this information is used by [`crate::type_check`] to make
+    /// sure that all required types are provided _before_ execution.
+    ///
+    /// The algorithm is as follows:
+    ///  1. If the second handler's signature is [`HandlerSignature::Entry`],
+    /// then **panic**.
+    ///  2. If the first handler's signature is [`HandlerSignature::Entry`] and
+    /// that of the second one is [`HandlerSignature::Other`], then the
+    /// signature of the resulting handler is taken from the second one.
+    ///  3. If the first handler's signature is [`HandlerSignature::Other`] and
+    /// that the second one is also [`HandlerSignature::Other`], then the
+    /// signature of the resulting handler is `HandlerSignature::Other {
+    /// input_types: self_input_types UNION next_input_types, output_types:
+    /// next_output_types INTERSECTION self_output_types }`.
     ///
     /// # Examples
     ///
@@ -159,17 +268,51 @@ where
     {
         let required_update_kinds_set = self.description().merge_branch(next.description());
 
-        from_fn_with_description(required_update_kinds_set, move |event, cont| {
-            let this = self.clone();
-            let next = next.clone();
+        let new_sig = match (&self.data.sig, &next.data.sig) {
+            (_, HandlerSignature::Entry) => {
+                panic!("Ill-typed handler branch: the second handler cannot be an entry")
+            }
+            (HandlerSignature::Entry, HandlerSignature::Other { .. }) => next.data.sig.clone(),
+            (
+                HandlerSignature::Other {
+                    input_types: self_input_types,
+                    output_types: self_output_types,
+                },
+                HandlerSignature::Other {
+                    input_types: next_input_types,
+                    output_types: next_output_types,
+                },
+            ) => {
+                HandlerSignature::Other {
+                    // Since any of the two handlers can end up being executed, take the union of
+                    // the input types of both handlers.
+                    input_types: self_input_types.union(next_input_types).cloned().collect(),
 
-            this.execute(event, |event| async move {
-                match next.dispatch(event).await {
-                    ControlFlow::Continue(event) => cont(event).await,
-                    done => done,
+                    // Since any of the two handlers can end up being executed, take the
+                    // intersection of the output types of both handlers.
+                    output_types: next_output_types
+                        .intersection(self_output_types)
+                        .cloned()
+                        .collect(),
                 }
-            })
-        })
+            }
+        };
+
+        from_fn_with_description(
+            required_update_kinds_set,
+            move |event, cont| {
+                let this = self.clone();
+                let next = next.clone();
+
+                this.execute(event, |event| async move {
+                    match next.dispatch(event).await {
+                        ControlFlow::Continue(event) => cont(event).await,
+                        done => done,
+                    }
+                })
+            },
+            new_sig,
+        )
     }
 
     /// Executes this handler with a continuation.
@@ -177,6 +320,11 @@ where
     /// Usually, you do not want to call this method by yourself, if you do not
     /// write your own handler implementation. If you wish to execute handler
     /// without a continuation, take a look at the [`Handler::dispatch`] method.
+    ///
+    /// **NOTE**: If you are using [`DependencyMap`], you should first call
+    /// [`crate::type_check`] to type-check your handler against a container;
+    /// otherwise, type checking will be delayed until the actual execution,
+    /// which can make things harder to debug.
     ///
     /// # Examples
     ///
@@ -194,7 +342,7 @@ where
     /// ```
     pub async fn execute<Cont, ContFut>(
         self,
-        container: Input,
+        input: Input,
         cont: Cont,
     ) -> ControlFlow<Output, Input>
     where
@@ -202,37 +350,78 @@ where
         Cont: Send + Sync + 'a,
         ContFut: Future<Output = ControlFlow<Output, Input>> + Send + 'a,
     {
-        (self.data.f)(container, Box::new(|event| Box::pin(cont(event)))).await
+        (self.data.f)(input, Box::new(|event| Box::pin(cont(event)))).await
     }
 
     /// Executes this handler.
     ///
     /// Returns [`ControlFlow::Break`] when executed successfully,
     /// [`ControlFlow::Continue`] otherwise.
-    pub async fn dispatch(&self, container: Input) -> ControlFlow<Output, Input> {
-        self.clone().execute(container, |event| async move { ControlFlow::Continue(event) }).await
+    ///
+    /// **NOTE**: If you are using [`DependencyMap`], you should first call
+    /// [`crate::type_check`] to type-check your handler against a container;
+    /// otherwise, type checking will be delayed until the actual execution,
+    /// which can make things harder to debug.
+    pub async fn dispatch(&self, input: Input) -> ControlFlow<Output, Input> {
+        self.clone().execute(input, |event| async move { ControlFlow::Continue(event) }).await
     }
 
     /// Returns the set of updates that can be processed by this handler.
     pub fn description(&self) -> &Descr {
         &self.data.description
     }
+
+    /// Returns this handler's run-time type signature.
+    pub fn sig(&self) -> &HandlerSignature {
+        &self.data.sig
+    }
+}
+
+fn print_rt_types<'a>(types: impl IntoIterator<Item = &'a Type>) -> String {
+    let mut res = String::new();
+    let mut types = types.into_iter();
+
+    if let Some(ty) = types.next() {
+        write!(res, "{}", ty.name).unwrap();
+    }
+    for ty in types {
+        write!(res, ", {}", ty.name).unwrap();
+    }
+
+    res
+}
+
+impl Type {
+    /// Constructs [`Type`] from a static type.
+    #[must_use]
+    pub fn of<T>() -> Self
+    where
+        T: 'static,
+    {
+        Self { id: TypeId::of::<T>(), name: std::any::type_name::<T>() }
+    }
 }
 
 /// Constructs a handler from a function.
+///
+/// `sig` is the run-time handler signature used for type inference and
+/// checking.
 ///
 /// Most of the time, you do not want to use this function. Take a look at more
 /// specialised functions: [`crate::endpoint`], [`crate::filter`],
 /// [`crate::filter_map`], etc.
 #[must_use]
-pub fn from_fn<'a, F, Fut, Input, Output, Descr>(f: F) -> Handler<'a, Input, Output, Descr>
+pub fn from_fn<'a, F, Fut, Input, Output, Descr>(
+    f: F,
+    sig: HandlerSignature,
+) -> Handler<'a, Input, Output, Descr>
 where
     F: Fn(Input, Cont<'a, Input, Output>) -> Fut,
     F: Send + Sync + 'a,
     Fut: Future<Output = ControlFlow<Output, Input>> + Send + 'a,
     Descr: HandlerDescription,
 {
-    from_fn_with_description(Descr::user_defined(), f)
+    from_fn_with_description(Descr::user_defined(), f, sig)
 }
 
 /// [`from_fn`] with a custom description.
@@ -240,6 +429,7 @@ where
 pub fn from_fn_with_description<'a, F, Fut, Input, Output, Descr>(
     description: Descr,
     f: F,
+    sig: HandlerSignature,
 ) -> Handler<'a, Input, Output, Descr>
 where
     F: Fn(Input, Cont<'a, Input, Output>) -> Fut,
@@ -250,6 +440,7 @@ where
         data: Arc::new(HandlerData {
             f: move |event, cont| Box::pin(f(event, cont)) as HandlerResult<_, _>,
             description,
+            sig,
         }),
     }
 }
@@ -258,6 +449,10 @@ where
 ///
 /// This function is only used to specify other handlers upon it (see the root
 /// examples).
+///
+/// # Signature
+///
+/// The run-time type signature of this handler is `HandlerSignature::Entry`.
 #[must_use]
 #[track_caller]
 pub fn entry<'a, Input, Output, Descr>() -> Handler<'a, Input, Output, Descr>
@@ -266,7 +461,63 @@ where
     Output: 'a,
     Descr: HandlerDescription,
 {
-    from_fn_with_description(Descr::entry(), |event, cont| cont(event))
+    from_fn_with_description(Descr::entry(), |event, cont| cont(event), HandlerSignature::Entry)
+}
+
+/// Performs run-time type checking.
+///
+/// If you are using [`DependencyMap`], you should call this function _before_
+/// executing the handler via [`Handler::execute`] or [`Handler::dispatch`]. If
+/// you do _not_ call this function before execution, type checking will be
+/// delayed until the actual execution, which can make things harder to debug.
+///
+/// `sig` can be obtained from [`Handler::sig`].
+///
+/// # Panics
+///
+/// If `container` does not contain all the types that the handler accepts.
+///
+/// # Examples
+///
+/// ```should_panic
+/// use dptree::prelude::*;
+///
+/// #[derive(Clone)]
+/// struct A;
+/// #[derive(Clone)]
+/// struct B;
+///
+/// // Requires both `A` and `B` to be present in the container.
+/// let handler: Handler<DependencyMap, ()> =
+///     dptree::entry().filter(|_: A| true).endpoint(|_: B| async { () });
+///
+/// // Ok.
+/// dptree::type_check(handler.sig(), &dptree::deps![A, B]);
+///
+/// // Panics with a proper message.
+/// dptree::type_check(handler.sig(), &dptree::deps![A /* Missing `B` */]);
+/// ```
+pub fn type_check(sig: &HandlerSignature, container: &DependencyMap) {
+    match sig {
+        HandlerSignature::Entry => {}
+        HandlerSignature::Other { input_types, output_types: _ } => {
+            let container_types = container
+                .map
+                .iter()
+                .map(|(type_id, dep)| Type { id: *type_id, name: dep.type_name })
+                .collect::<HashSet<_>>();
+
+            if !input_types.is_subset(&container_types) {
+                panic!(
+                    "This handler accepts the following types:\n    {}\n, but only the following \
+                     types are provided:\n    {}\nThe missing types are:\n    {}",
+                    print_rt_types(input_types),
+                    print_rt_types(&container_types),
+                    print_rt_types(input_types.difference(&container_types))
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -293,10 +544,16 @@ mod tests {
         let input = 123;
         let output = "ABC";
 
-        let result = help_inference(from_fn(|event, _cont: Cont<i32, &'static str>| async move {
-            assert_eq!(event, input);
-            ControlFlow::Break(output)
-        }))
+        let result = help_inference(from_fn(
+            |event, _cont: Cont<i32, &'static str>| async move {
+                assert_eq!(event, input);
+                ControlFlow::Break(output)
+            },
+            HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<i32>()]),
+                output_types: HashSet::from([]),
+            },
+        ))
         .dispatch(input)
         .await;
 
@@ -308,13 +565,18 @@ mod tests {
         let input = 123;
         type Output = &'static str;
 
-        let result =
-            help_inference(from_fn(|event: i32, _cont: Cont<i32, &'static str>| async move {
+        let result = help_inference(from_fn(
+            |event: i32, _cont: Cont<i32, &'static str>| async move {
                 assert_eq!(event, input);
                 ControlFlow::<Output, _>::Continue(event)
-            }))
-            .dispatch(input)
-            .await;
+            },
+            HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<i32>()]),
+                output_types: HashSet::from([Type::of::<i32>()]),
+            },
+        ))
+        .dispatch(input)
+        .await;
 
         assert!(result == ControlFlow::Continue(input));
     }
@@ -334,10 +596,16 @@ mod tests {
         let input = 123;
         let output = "ABC";
 
-        let result = help_inference(from_fn(|event, cont| {
-            assert!(event == input);
-            cont(event)
-        }))
+        let result = help_inference(from_fn(
+            |event, cont| {
+                assert!(event == input);
+                cont(event)
+            },
+            HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<i32>()]),
+                output_types: HashSet::from([Type::of::<i32>()]),
+            },
+        ))
         .execute(input, |event| async move {
             assert!(event == input);
             ControlFlow::Break(output)
@@ -507,5 +775,170 @@ mod tests {
 
         // Chained non-overlapping filters do not allow anything.
         assert(filter_a().chain(filter_b()).endpoint(|| async {}), hashset! {});
+    }
+
+    #[tokio::test]
+    async fn test_type_check() {
+        #[derive(Clone)]
+        struct A;
+        #[derive(Clone)]
+        struct B;
+        #[derive(Clone)]
+        struct C;
+
+        let deps = deps![A, B, C];
+
+        // Type checking an entry must always succeed.
+        type_check(&HandlerSignature::Entry, &deps);
+
+        // The case for the same handler's input types and those in the container.
+        type_check(
+            &HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<A>(), Type::of::<B>(), Type::of::<C>()]),
+                output_types: HashSet::from([]),
+            },
+            &deps,
+        );
+
+        // The case for handler's input types and a superset thereof in the container.
+        type_check(
+            &HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<A>(), Type::of::<B>()]),
+                output_types: HashSet::from([]),
+            },
+            &deps,
+        );
+    }
+
+    #[test]
+    // Cannot specify the exact panic message because `HashSet` is iterated in a random order.
+    #[should_panic]
+    fn type_check_panic() {
+        #[derive(Clone)]
+        struct A;
+        #[derive(Clone)]
+        struct B;
+        #[derive(Clone)]
+        struct C;
+
+        type_check(
+            &HandlerSignature::Other {
+                input_types: HashSet::from([Type::of::<A>(), Type::of::<B>(), Type::of::<C>()]),
+                output_types: HashSet::from([]),
+            },
+            // `C` is required but not provided.
+            &deps![A, B],
+        );
+    }
+
+    #[tokio::test]
+    async fn type_infer_check_chained_combinators() {
+        #[derive(Clone)]
+        struct A;
+        #[derive(Clone)]
+        struct B;
+        #[derive(Clone)]
+        struct C;
+        #[derive(Clone)]
+        struct D;
+        #[derive(Clone)]
+        struct E;
+        #[derive(Clone)]
+        struct F;
+        #[derive(Clone)]
+        struct G;
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct H;
+
+        let h: Handler<DependencyMap, H> = entry()
+            .map(|/* In the final input types. */ _: A| B)
+            .inspect(
+                |/* This type must be removed from the final input types because it is
+                  * provided by the `.map` above. */
+                 _: B,
+                 /* This type must "propagate" to the final input types. */
+                 _: E| (),
+            )
+            .filter_map(|/* In the final input types. */ _: C| Some(D))
+            .filter(
+                |/* This type is provided by the `.filter_map` above. */ _: D,
+                 /* Must propagate. */ _: F| true,
+            )
+            .endpoint(
+                /* `B` and `D` are provided at this point. */
+                |_: B, _: D, /* Must propagate. */ _: G| async { H },
+            );
+
+        assert_eq!(
+            h.sig(),
+            &HandlerSignature::Other {
+                input_types: HashSet::from([
+                    Type::of::<A>(),
+                    Type::of::<C>(),
+                    Type::of::<E>(),
+                    Type::of::<F>(),
+                    Type::of::<G>()
+                ]),
+                output_types: HashSet::from([Type::of::<B>(), Type::of::<D>()])
+            }
+        );
+
+        let deps = deps![A, C, E, F, G];
+
+        type_check(h.sig(), &deps);
+
+        // Must not panic during execution.
+        assert_eq!(h.dispatch(deps).await, ControlFlow::Break(H));
+    }
+
+    #[tokio::test]
+    async fn type_infer_check_branched_combinators() {
+        #[derive(Clone)]
+        struct A;
+        #[derive(Clone)]
+        struct B;
+        #[derive(Clone)]
+        struct C;
+        #[derive(Clone)]
+        struct D;
+        #[derive(Clone)]
+        struct E;
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct F;
+
+        let h: Handler<DependencyMap, F> = entry()
+            .branch(
+                crate::inspect(|_: A| ()).map(|| B).map(|| C).map(|| D).endpoint(|| async { F }),
+            )
+            .branch(crate::inspect(|_: E| ()).map(|| B).map(|| D).endpoint(|| async { F }));
+
+        assert_eq!(
+            h.sig(),
+            &HandlerSignature::Other {
+                // The union of the input types of both branches.
+                input_types: HashSet::from([Type::of::<A>(), Type::of::<E>(),]),
+                // The intersection of the output types of both branches.
+                output_types: HashSet::from([Type::of::<B>(), Type::of::<D>()])
+            }
+        );
+
+        let deps = deps![A, E];
+
+        type_check(h.sig(), &deps);
+
+        // Must not panic during execution.
+        assert_eq!(h.dispatch(deps).await, ControlFlow::Break(F));
+    }
+
+    #[test]
+    #[should_panic(expected = "Ill-typed handler chain: the second handler cannot be an entry")]
+    fn chain_entry() {
+        let _: Handler<(), ()> = entry().chain(entry());
+    }
+
+    #[test]
+    #[should_panic(expected = "Ill-typed handler branch: the second handler cannot be an entry")]
+    fn branch_entry() {
+        let _: Handler<(), ()> = entry().branch(entry());
     }
 }

--- a/src/handler/description.rs
+++ b/src/handler/description.rs
@@ -8,8 +8,8 @@ pub use unspecified::Unspecified;
 
 /// Handler description.
 ///
-/// This trait allows information to flow "back up" the tree, allowing to check
-/// its structure.
+/// This trait allows information to flow "back up" the tree, allowing a user to
+/// check its structure.
 ///
 /// ## Examples
 ///

--- a/src/handler/description.rs
+++ b/src/handler/description.rs
@@ -44,7 +44,7 @@ pub use unspecified::Unspecified;
 /// }
 ///
 /// assert_count(0, dptree::entry());
-/// assert_count(1, dptree::entry().branch(dptree::entry()));
+/// assert_count(1, dptree::entry().branch(dptree::inspect(|| ())));
 /// assert_count(
 ///     5,
 ///     dptree::entry()
@@ -53,7 +53,7 @@ pub use unspecified::Unspecified;
 ///                 .branch(dptree::entry().branch(dptree::filter(|| true)))
 ///                 .branch(dptree::entry().chain(dptree::filter(|| false))),
 ///         )
-///         .branch(dptree::entry()),
+///         .branch(dptree::inspect(|| ())),
 /// );
 /// ```
 pub trait HandlerDescription: Sized + Send + Sync + 'static {

--- a/src/handler/description.rs
+++ b/src/handler/description.rs
@@ -39,7 +39,7 @@ pub use unspecified::Unspecified;
 /// }
 ///
 /// #[track_caller]
-/// fn assert_count(count: u32, handler: Handler<DependencyMap, (), CountBranches>) {
+/// fn assert_count(count: u32, handler: Handler<(), CountBranches>) {
 ///     assert_eq!(handler.description().0, count);
 /// }
 ///

--- a/src/handler/description/interest_set.rs
+++ b/src/handler/description/interest_set.rs
@@ -45,7 +45,7 @@ impl<K: EventKind<S>, S> InterestSet<K, S> {
     /// use maplit::hashset;
     ///
     /// # enum K {} impl EventKind for K { fn full_set() -> std::collections::HashSet<Self> { hashset!{} } fn empty_set() -> std::collections::HashSet<Self> { hashset!{} } }
-    /// # let _: dptree::Handler<(), (), InterestSet<K>> =
+    /// # let _: dptree::Handler<(), InterestSet<K>> =
     /// filter_with_description(InterestSet::new_filter(hashset! {}), || {
     ///     println!("Filter called!"); // <-- bad
     ///
@@ -53,7 +53,7 @@ impl<K: EventKind<S>, S> InterestSet<K, S> {
     /// });
     ///
     /// # #[derive(Clone)] struct Db; impl Db { fn fetch_enabled(&self) -> bool { false } }
-    /// # let _: dptree::Handler<dptree::di::DependencyMap, (), InterestSet<K>> =
+    /// # let _: dptree::Handler<(), InterestSet<K>> =
     /// filter_with_description(InterestSet::new_filter(hashset! {}), |db: Db| {
     ///     let pass = db.fetch_enabled(); // <-- fine
     ///

--- a/src/handler/description/interest_set.rs
+++ b/src/handler/description/interest_set.rs
@@ -110,7 +110,7 @@ where
             tmp
         };
 
-        // If we chain two filters together, we are only interested in events that can
+        // If we chain two filters together, we are only passing through events that can
         // pass both of them.
         let filtered = {
             let hasher = l_flt.hasher().clone();

--- a/src/handler/description/interest_set.rs
+++ b/src/handler/description/interest_set.rs
@@ -2,10 +2,8 @@ use crate::HandlerDescription;
 
 use std::{
     collections::HashSet,
-    hash::{BuildHasher, Hash},
+    hash::{BuildHasher, Hash, RandomState},
 };
-
-use rustc_hash::FxBuildHasher;
 
 /// Description for a handler that describes what event kinds are interesting to
 /// the handler.
@@ -14,7 +12,7 @@ use rustc_hash::FxBuildHasher;
 /// `dptree`. In this case you should keep updates that are in the `observed`
 /// set.
 #[derive(Debug, Clone)]
-pub struct InterestSet<K, S = FxBuildHasher> {
+pub struct InterestSet<K, S = RandomState> {
     /// Event kinds that are of interested for a given handler.
     ///
     /// I.e. the ones that can cause meaningful side-effects.
@@ -28,7 +26,7 @@ pub struct InterestSet<K, S = FxBuildHasher> {
 ///
 /// Usually this would be implemented by a field-less enumeration of all update
 /// kinds.
-pub trait EventKind<S = FxBuildHasher>: Sized {
+pub trait EventKind<S = RandomState>: Sized {
     /// Set of all event kinds.
     fn full_set() -> HashSet<Self, S>;
 
@@ -44,11 +42,11 @@ impl<K: EventKind<S>, S> InterestSet<K, S> {
     /// example:
     /// ```
     /// use dptree::{description::{InterestSet, EventKind}, filter_with_description};
-    /// use rustc_hash::FxHashSet;
+    /// use std::collections::HashSet;
     ///
-    /// # enum K {} impl EventKind for K { fn full_set() -> FxHashSet<Self> { FxHashSet::default() } fn empty_set() -> FxHashSet<Self> { FxHashSet::default() } }
+    /// # enum K {} impl EventKind for K { fn full_set() -> HashSet<Self> { HashSet::default() } fn empty_set() -> HashSet<Self> { HashSet::default() } }
     /// # let _: dptree::Handler<(), InterestSet<K>> =
-    /// filter_with_description(InterestSet::new_filter(FxHashSet::default()), || {
+    /// filter_with_description(InterestSet::new_filter(HashSet::new()), || {
     ///     println!("Filter called!"); // <-- bad
     ///
     ///     false
@@ -56,7 +54,7 @@ impl<K: EventKind<S>, S> InterestSet<K, S> {
     ///
     /// # #[derive(Clone)] struct Db; impl Db { fn fetch_enabled(&self) -> bool { false } }
     /// # let _: dptree::Handler<(), InterestSet<K>> =
-    /// filter_with_description(InterestSet::new_filter(FxHashSet::default()), |db: Db| {
+    /// filter_with_description(InterestSet::new_filter(HashSet::new()), |db: Db| {
     ///     let pass = db.fetch_enabled(); // <-- fine
     ///
     ///     pass

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -14,7 +14,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: HashSet::from([]) }`.
+/// input_types: F::input_types(), output_types: HashSet::new() }`.
 #[must_use]
 #[track_caller]
 pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
@@ -36,7 +36,7 @@ where
         },
         HandlerSignature::Other {
             input_types: F::input_types(),
-            output_types: HashSet::from([]),
+            output_types: HashSet::new(),
             obligations: F::obligations(),
         },
     )

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -14,10 +14,10 @@ use rustc_hash::FxHashSet;
 /// completion. So, you can use it when your chain of responsibility must end
 /// up, and handle an incoming event.
 ///
-/// # Signature
+/// # Run-time signature
 ///
-/// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: FxHashSet::new() }`.
+/// - Obligations: `F::obligations()`
+/// - Outcomes: `FxHashSet::default()`
 #[must_use]
 #[track_caller]
 pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
@@ -37,11 +37,7 @@ where
                 f().map(ControlFlow::Break).await
             }
         },
-        HandlerSignature::Other {
-            input_types: F::input_types(),
-            output_types: FxHashSet::default(),
-            obligations: F::obligations(),
-        },
+        HandlerSignature::Other { obligations: F::obligations(), outcomes: FxHashSet::default() },
     )
 }
 

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -35,7 +35,11 @@ where
                 f().map(ControlFlow::Break).await
             }
         },
-        HandlerSignature::Other { input_types: F::input_types(), output_types: HashSet::from([]) },
+        HandlerSignature::Other {
+            input_types: F::input_types(),
+            output_types: HashSet::from([]),
+            obligations: F::obligations(),
+        },
     )
 }
 

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -2,8 +2,11 @@ use crate::{
     description, di::Injectable, from_fn_with_description, Handler, HandlerDescription,
     HandlerSignature,
 };
+
+use std::{ops::ControlFlow, sync::Arc};
+
 use futures::FutureExt;
-use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
+use rustc_hash::FxHashSet;
 
 /// Constructs a handler that has no further handlers in a chain.
 ///
@@ -14,7 +17,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: HashSet::new() }`.
+/// input_types: F::input_types(), output_types: FxHashSet::new() }`.
 #[must_use]
 #[track_caller]
 pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
@@ -36,7 +39,7 @@ where
         },
         HandlerSignature::Other {
             input_types: F::input_types(),
-            output_types: HashSet::new(),
+            output_types: FxHashSet::default(),
             obligations: F::obligations(),
         },
     )

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -17,10 +17,9 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// input_types: F::input_types(), output_types: HashSet::from([]) }`.
 #[must_use]
 #[track_caller]
-pub fn endpoint<'a, F, Input, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Input, Output, Descr>
+pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
 where
-    F: Injectable<Input, Output, FnArgs> + Send + Sync + 'a,
-    Input: Send + 'a,
+    F: Injectable<Output, FnArgs> + Send + Sync + 'a,
     Output: 'static,
     Descr: HandlerDescription,
 {
@@ -44,8 +43,7 @@ where
 }
 
 /// A handler with no further handlers in a chain.
-pub type Endpoint<'a, Input, Output, Descr = description::Unspecified> =
-    Handler<'a, Input, Output, Descr>;
+pub type Endpoint<'a, Output, Descr = description::Unspecified> = Handler<'a, Output, Descr>;
 
 #[cfg(test)]
 mod tests {

--- a/src/handler/endpoint.rs
+++ b/src/handler/endpoint.rs
@@ -3,10 +3,9 @@ use crate::{
     HandlerSignature,
 };
 
-use std::{ops::ControlFlow, sync::Arc};
+use std::{collections::BTreeSet, ops::ControlFlow, sync::Arc};
 
 use futures::FutureExt;
-use rustc_hash::FxHashSet;
 
 /// Constructs a handler that has no further handlers in a chain.
 ///
@@ -17,7 +16,7 @@ use rustc_hash::FxHashSet;
 /// # Run-time signature
 ///
 /// - Obligations: `F::obligations()`
-/// - Outcomes: `FxHashSet::default()`
+/// - Outcomes: `BTreeSet::default()`
 #[must_use]
 #[track_caller]
 pub fn endpoint<'a, F, Output, FnArgs, Descr>(f: F) -> Endpoint<'a, Output, Descr>
@@ -37,7 +36,7 @@ where
                 f().map(ControlFlow::Break).await
             }
         },
-        HandlerSignature::Other { obligations: F::obligations(), outcomes: FxHashSet::default() },
+        HandlerSignature::Other { obligations: F::obligations(), outcomes: BTreeSet::default() },
     )
 }
 

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -4,7 +4,10 @@ use crate::{
     handler::core::Handler,
     HandlerDescription, HandlerSignature,
 };
-use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
+
+use std::{ops::ControlFlow, sync::Arc};
+
+use rustc_hash::FxHashSet;
 
 /// Constructs a handler that filters input with the predicate `pred`.
 ///
@@ -15,7 +18,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: Pred::input_types(), output_types: HashSet::new() }`.
+/// input_types: Pred::input_types(), output_types: FxHashSet::default() }`.
 #[must_use]
 #[track_caller]
 pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
@@ -85,7 +88,7 @@ where
         },
         HandlerSignature::Other {
             input_types: Pred::input_types(),
-            output_types: HashSet::new(),
+            output_types: FxHashSet::default(),
             obligations: Pred::obligations(),
         },
     )

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -15,10 +15,10 @@ use rustc_hash::FxHashSet;
 /// If it returns `true`, a continuation of the handler will be called,
 /// otherwise the handler returns [`ControlFlow::Continue`].
 ///
-/// # Signature
+/// # Run-time signature
 ///
-/// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: Pred::input_types(), output_types: FxHashSet::default() }`.
+/// - Obligations: `Pred::obligations()`
+/// - Outcomes: `FxHashSet::default()`
 #[must_use]
 #[track_caller]
 pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
@@ -87,9 +87,8 @@ where
             }
         },
         HandlerSignature::Other {
-            input_types: Pred::input_types(),
-            output_types: FxHashSet::default(),
             obligations: Pred::obligations(),
+            outcomes: FxHashSet::default(),
         },
     )
 }

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -5,9 +5,7 @@ use crate::{
     HandlerDescription, HandlerSignature,
 };
 
-use std::{ops::ControlFlow, sync::Arc};
-
-use rustc_hash::FxHashSet;
+use std::{collections::BTreeSet, ops::ControlFlow, sync::Arc};
 
 /// Constructs a handler that filters input with the predicate `pred`.
 ///
@@ -18,7 +16,7 @@ use rustc_hash::FxHashSet;
 /// # Run-time signature
 ///
 /// - Obligations: `Pred::obligations()`
-/// - Outcomes: `FxHashSet::default()`
+/// - Outcomes: `BTreeSet::default()`
 #[must_use]
 #[track_caller]
 pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
@@ -86,10 +84,7 @@ where
                 }
             }
         },
-        HandlerSignature::Other {
-            obligations: Pred::obligations(),
-            outcomes: FxHashSet::default(),
-        },
+        HandlerSignature::Other { obligations: Pred::obligations(), outcomes: BTreeSet::default() },
     )
 }
 

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -47,6 +47,7 @@ where
 
 /// [`filter`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn filter_with_description<'a, Pred, Input, Output, FnArgs, Descr>(
     description: Descr,
     pred: Pred,
@@ -61,6 +62,7 @@ where
 
 /// [`filter_async`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn filter_async_with_description<'a, Pred, Input, Output, FnArgs, Descr>(
     description: Descr,
     pred: Pred,
@@ -92,6 +94,7 @@ where
         HandlerSignature::Other {
             input_types: Pred::input_types(),
             output_types: HashSet::from([]),
+            obligations: Pred::obligations(),
         },
     )
 }

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -18,12 +18,9 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// input_types: Pred::input_types(), output_types: HashSet::from([]) }`.
 #[must_use]
 #[track_caller]
-pub fn filter<'a, Pred, Input, Output, FnArgs, Descr>(
-    pred: Pred,
-) -> Handler<'a, Input, Output, Descr>
+pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Pred>: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -33,12 +30,9 @@ where
 /// The asynchronous version of [`filter`].
 #[must_use]
 #[track_caller]
-pub fn filter_async<'a, Pred, Input, Output, FnArgs, Descr>(
-    pred: Pred,
-) -> Handler<'a, Input, Output, Descr>
+pub fn filter_async<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
 where
-    Pred: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -48,13 +42,12 @@ where
 /// [`filter`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn filter_with_description<'a, Pred, Input, Output, FnArgs, Descr>(
+pub fn filter_with_description<'a, Pred, Output, FnArgs, Descr>(
     description: Descr,
     pred: Pred,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Asyncify<Pred>: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
     Output: 'a,
 {
     filter_async_with_description(description, Asyncify(pred))
@@ -63,13 +56,12 @@ where
 /// [`filter_async`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn filter_async_with_description<'a, Pred, Input, Output, FnArgs, Descr>(
+pub fn filter_async_with_description<'a, Pred, Output, FnArgs, Descr>(
     description: Descr,
     pred: Pred,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Pred: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
     Output: 'a,
 {
     let pred = Arc::new(pred);

--- a/src/handler/filter.rs
+++ b/src/handler/filter.rs
@@ -15,7 +15,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: Pred::input_types(), output_types: HashSet::from([]) }`.
+/// input_types: Pred::input_types(), output_types: HashSet::new() }`.
 #[must_use]
 #[track_caller]
 pub fn filter<'a, Pred, Output, FnArgs, Descr>(pred: Pred) -> Handler<'a, Output, Descr>
@@ -85,7 +85,7 @@ where
         },
         HandlerSignature::Other {
             input_types: Pred::input_types(),
-            output_types: HashSet::from([]),
+            output_types: HashSet::new(),
             obligations: Pred::obligations(),
         },
     )

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -14,11 +14,10 @@ use rustc_hash::FxHashSet;
 /// `None`, then the handler will return [`ControlFlow::Continue`] with the old
 /// container.
 ///
-/// # Signature
+/// # Run-time signature
 ///
-/// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: Projection::input_types(), output_types:
-/// FxHashSet::from_iter(vec![Type::of::<NewType>()]) }`.
+/// - Obligations: `Projection::obligations()`
+/// - Outcomes: `FxHashSet::from_iter(vec![Type::of::<NewType>()])`
 #[must_use]
 #[track_caller]
 pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(
@@ -101,9 +100,8 @@ where
             }
         },
         HandlerSignature::Other {
-            input_types: Projection::input_types(),
-            output_types: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
             obligations: Projection::obligations(),
+            outcomes: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
         },
     )
 }

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -18,7 +18,7 @@ use rustc_hash::FxHashSet;
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
 /// input_types: Projection::input_types(), output_types:
-/// FxHashSet::from([RtType::of::<NewType>()]) }`.
+/// FxHashSet::from_iter(vec![Type::of::<NewType>()]) }`.
 #[must_use]
 #[track_caller]
 pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -2,7 +2,10 @@ use crate::{
     di::{Asyncify, Injectable},
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
-use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
+
+use std::{iter::FromIterator, ops::ControlFlow, sync::Arc};
+
+use rustc_hash::FxHashSet;
 
 /// Constructs a handler that optionally passes a value of a new type further.
 ///
@@ -15,7 +18,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
 /// input_types: Projection::input_types(), output_types:
-/// HashSet::from([RtType::of::<NewType>()]) }`.
+/// FxHashSet::from([RtType::of::<NewType>()]) }`.
 #[must_use]
 #[track_caller]
 pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(
@@ -99,7 +102,7 @@ where
         },
         HandlerSignature::Other {
             input_types: Projection::input_types(),
-            output_types: HashSet::from([Type::of::<NewType>()]),
+            output_types: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
             obligations: Projection::obligations(),
         },
     )

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -51,6 +51,7 @@ where
 
 /// [`filter_map`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn filter_map_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
@@ -67,6 +68,7 @@ where
 
 /// [`filter_map_async`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn filter_map_async_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
@@ -106,6 +108,7 @@ where
         HandlerSignature::Other {
             input_types: Projection::input_types(),
             output_types: HashSet::from([Type::of::<NewType>()]),
+            obligations: Projection::obligations(),
         },
     )
 }

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    di::{Asyncify, Injectable, Insert},
+    di::{Asyncify, Injectable},
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
 use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
@@ -18,16 +18,14 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// HashSet::from([RtType::of::<NewType>()]) }`.
 #[must_use]
 #[track_caller]
-pub fn filter_map<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Asyncify<Projection>: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Asyncify<Projection>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     filter_map_with_description(Descr::filter_map(), proj)
 }
@@ -35,16 +33,14 @@ where
 /// The asynchronous version of [`filter_map`].
 #[must_use]
 #[track_caller]
-pub fn filter_map_async<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn filter_map_async<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Projection: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Projection: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     filter_map_async_with_description(Descr::filter_map_async(), proj)
 }
@@ -52,16 +48,14 @@ where
 /// [`filter_map`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn filter_map_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn filter_map_with_description<'a, Projection, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Asyncify<Projection>: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Asyncify<Projection>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
     Output: 'a,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     filter_map_async_with_description(description, Asyncify(proj))
 }
@@ -69,22 +63,20 @@ where
 /// [`filter_map_async`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn filter_map_async_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn filter_map_async_with_description<'a, Projection, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Projection: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Projection: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
     Output: 'a,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     let proj = Arc::new(proj);
 
     from_fn_with_description(
         description,
-        move |container: Input, cont| {
+        move |container, cont| {
             let proj = Arc::clone(&proj);
 
             async move {

--- a/src/handler/filter_map.rs
+++ b/src/handler/filter_map.rs
@@ -3,9 +3,7 @@ use crate::{
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
 
-use std::{iter::FromIterator, ops::ControlFlow, sync::Arc};
-
-use rustc_hash::FxHashSet;
+use std::{collections::BTreeSet, iter::FromIterator, ops::ControlFlow, sync::Arc};
 
 /// Constructs a handler that optionally passes a value of a new type further.
 ///
@@ -17,7 +15,7 @@ use rustc_hash::FxHashSet;
 /// # Run-time signature
 ///
 /// - Obligations: `Projection::obligations()`
-/// - Outcomes: `FxHashSet::from_iter(vec![Type::of::<NewType>()])`
+/// - Outcomes: `BTreeSet::from_iter(vec![Type::of::<NewType>()])`
 #[must_use]
 #[track_caller]
 pub fn filter_map<'a, Projection, Output, NewType, Args, Descr>(
@@ -101,7 +99,7 @@ where
         },
         HandlerSignature::Other {
             obligations: Projection::obligations(),
-            outcomes: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
+            outcomes: BTreeSet::from_iter(vec![Type::of::<NewType>()]),
         },
     )
 }

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -41,6 +41,7 @@ where
 
 /// [`inspect`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn inspect_with_description<'a, F, Input, Output, Args, Descr>(
     description: Descr,
     f: F,
@@ -55,6 +56,7 @@ where
 
 /// [`inspect_async`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn inspect_async_with_description<'a, F, Input, Output, Args, Descr>(
     description: Descr,
     f: F,
@@ -79,7 +81,11 @@ where
                 cont(x).await
             }
         },
-        HandlerSignature::Other { input_types: F::input_types(), output_types: HashSet::from([]) },
+        HandlerSignature::Other {
+            input_types: F::input_types(),
+            output_types: HashSet::from([]),
+            obligations: F::obligations(),
+        },
     )
 }
 

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -11,7 +11,7 @@ use std::{collections::HashSet, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: HashSet::from([]) }`.
+/// input_types: F::input_types(), output_types: HashSet::new() }`.
 ///
 /// [`map`]: crate::map
 #[must_use]
@@ -79,7 +79,7 @@ where
         },
         HandlerSignature::Other {
             input_types: F::input_types(),
-            output_types: HashSet::from([]),
+            output_types: HashSet::new(),
             obligations: F::obligations(),
         },
     )

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -3,7 +3,9 @@ use crate::{
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature,
 };
 
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
+
+use rustc_hash::FxHashSet;
 
 /// Constructs a handler that inspects current state. Like [`map`] but does not
 /// add return value of `f` to the container.
@@ -11,7 +13,7 @@ use std::{collections::HashSet, sync::Arc};
 /// # Signature
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: HashSet::new() }`.
+/// input_types: F::input_types(), output_types: FxHashSet::default() }`.
 ///
 /// [`map`]: crate::map
 #[must_use]
@@ -79,7 +81,7 @@ where
         },
         HandlerSignature::Other {
             input_types: F::input_types(),
-            output_types: HashSet::new(),
+            output_types: FxHashSet::default(),
             obligations: F::obligations(),
         },
     )

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -3,9 +3,7 @@ use crate::{
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature,
 };
 
-use std::sync::Arc;
-
-use rustc_hash::FxHashSet;
+use std::{collections::BTreeSet, sync::Arc};
 
 /// Constructs a handler that inspects current state. Like [`map`] but does not
 /// add return value of `f` to the container.
@@ -13,7 +11,7 @@ use rustc_hash::FxHashSet;
 /// # Run-time signature
 ///
 /// - Obligations: `F::obligations()`
-/// - Outcomes: `FxHashSet::default()`
+/// - Outcomes: `BTreeSet::default()`
 ///
 /// [`map`]: crate::map
 #[must_use]
@@ -79,7 +77,7 @@ where
                 cont(x).await
             }
         },
-        HandlerSignature::Other { obligations: F::obligations(), outcomes: FxHashSet::default() },
+        HandlerSignature::Other { obligations: F::obligations(), outcomes: BTreeSet::default() },
     )
 }
 

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -10,10 +10,10 @@ use rustc_hash::FxHashSet;
 /// Constructs a handler that inspects current state. Like [`map`] but does not
 /// add return value of `f` to the container.
 ///
-/// # Signature
+/// # Run-time signature
 ///
-/// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: F::input_types(), output_types: FxHashSet::default() }`.
+/// - Obligations: `F::obligations()`
+/// - Outcomes: `FxHashSet::default()`
 ///
 /// [`map`]: crate::map
 #[must_use]
@@ -79,11 +79,7 @@ where
                 cont(x).await
             }
         },
-        HandlerSignature::Other {
-            input_types: F::input_types(),
-            output_types: FxHashSet::default(),
-            obligations: F::obligations(),
-        },
+        HandlerSignature::Other { obligations: F::obligations(), outcomes: FxHashSet::default() },
     )
 }
 

--- a/src/handler/inspect.rs
+++ b/src/handler/inspect.rs
@@ -16,10 +16,9 @@ use std::{collections::HashSet, sync::Arc};
 /// [`map`]: crate::map
 #[must_use]
 #[track_caller]
-pub fn inspect<'a, F, Input, Output, Args, Descr>(f: F) -> Handler<'a, Input, Output, Descr>
+pub fn inspect<'a, F, Output, Args, Descr>(f: F) -> Handler<'a, Output, Descr>
 where
-    Asyncify<F>: Injectable<Input, (), Args> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -29,10 +28,9 @@ where
 /// The asynchronous version of [`inspect`].
 #[must_use]
 #[track_caller]
-pub fn inspect_async<'a, F, Input, Output, Args, Descr>(f: F) -> Handler<'a, Input, Output, Descr>
+pub fn inspect_async<'a, F, Output, Args, Descr>(f: F) -> Handler<'a, Output, Descr>
 where
-    F: Injectable<Input, (), Args> + Send + Sync + 'a,
-    Input: Send + 'a,
+    F: Injectable<(), Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
@@ -42,13 +40,12 @@ where
 /// [`inspect`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn inspect_with_description<'a, F, Input, Output, Args, Descr>(
+pub fn inspect_with_description<'a, F, Output, Args, Descr>(
     description: Descr,
     f: F,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Asyncify<F>: Injectable<Input, (), Args> + Send + Sync + 'a,
-    Input: Send + 'a,
+    Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
     Output: 'a,
 {
     inspect_async_with_description(description, Asyncify(f))
@@ -57,13 +54,12 @@ where
 /// [`inspect_async`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn inspect_async_with_description<'a, F, Input, Output, Args, Descr>(
+pub fn inspect_async_with_description<'a, F, Output, Args, Descr>(
     description: Descr,
     f: F,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    F: Injectable<Input, (), Args> + Send + Sync + 'a,
-    Input: Send + 'a,
+    F: Injectable<(), Args> + Send + Sync + 'a,
     Output: 'a,
 {
     let f = Arc::new(f);

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -14,11 +14,10 @@ use rustc_hash::FxHashSet;
 ///
 /// See also: [`crate::filter_map`].
 ///
-/// # Signature
+/// # Run-time signature
 ///
-/// The run-time type signature of this handler is `HandlerSignature::Other {
-/// input_types: Projection::input_types(), output_types:
-/// FxHashSet::from_iter(vec![Type::of::<NewType>()]) }`.
+/// - Obligations: `Projection::obligations()`
+/// - Outcomes: `FxHashSet::from_iter(vec![Type::of::<NewType>()])`
 #[must_use]
 #[track_caller]
 pub fn map<'a, Projection, Output, NewType, Args, Descr>(
@@ -98,9 +97,8 @@ where
             }
         },
         HandlerSignature::Other {
-            input_types: Projection::input_types(),
-            output_types: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
             obligations: Projection::obligations(),
+            outcomes: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
         },
     )
 }

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -51,6 +51,7 @@ where
 
 /// [`map`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn map_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
@@ -68,6 +69,7 @@ where
 
 /// [`map_async`] with a custom description.
 #[must_use]
+#[track_caller]
 pub fn map_async_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
@@ -103,6 +105,7 @@ where
         HandlerSignature::Other {
             input_types: Projection::input_types(),
             output_types: HashSet::from([Type::of::<NewType>()]),
+            obligations: Projection::obligations(),
         },
     )
 }

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -3,9 +3,7 @@ use crate::{
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
 
-use std::{iter::FromIterator, ops::ControlFlow, sync::Arc};
-
-use rustc_hash::FxHashSet;
+use std::{collections::BTreeSet, iter::FromIterator, ops::ControlFlow, sync::Arc};
 
 /// Constructs a handler that passes a value of a new type further.
 ///
@@ -17,7 +15,7 @@ use rustc_hash::FxHashSet;
 /// # Run-time signature
 ///
 /// - Obligations: `Projection::obligations()`
-/// - Outcomes: `FxHashSet::from_iter(vec![Type::of::<NewType>()])`
+/// - Outcomes: `BTreeSet::from_iter(vec![Type::of::<NewType>()])`
 #[must_use]
 #[track_caller]
 pub fn map<'a, Projection, Output, NewType, Args, Descr>(
@@ -98,7 +96,7 @@ where
         },
         HandlerSignature::Other {
             obligations: Projection::obligations(),
-            outcomes: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
+            outcomes: BTreeSet::from_iter(vec![Type::of::<NewType>()]),
         },
     )
 }

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -2,7 +2,10 @@ use crate::{
     di::{Asyncify, Injectable},
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
-use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
+
+use std::{iter::FromIterator, ops::ControlFlow, sync::Arc};
+
+use rustc_hash::FxHashSet;
 
 /// Constructs a handler that passes a value of a new type further.
 ///
@@ -15,7 +18,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 ///
 /// The run-time type signature of this handler is `HandlerSignature::Other {
 /// input_types: Projection::input_types(), output_types:
-/// HashSet::from([RtType::of::<NewType>()]) }`.
+/// FxHashSet::from_iter(vec![Type::of::<NewType>()]) }`.
 #[must_use]
 #[track_caller]
 pub fn map<'a, Projection, Output, NewType, Args, Descr>(
@@ -96,7 +99,7 @@ where
         },
         HandlerSignature::Other {
             input_types: Projection::input_types(),
-            output_types: HashSet::from([Type::of::<NewType>()]),
+            output_types: FxHashSet::from_iter(vec![Type::of::<NewType>()]),
             obligations: Projection::obligations(),
         },
     )

--- a/src/handler/map.rs
+++ b/src/handler/map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    di::{Asyncify, Injectable, Insert},
+    di::{Asyncify, Injectable},
     from_fn_with_description, Handler, HandlerDescription, HandlerSignature, Type,
 };
 use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
@@ -18,16 +18,14 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 /// HashSet::from([RtType::of::<NewType>()]) }`.
 #[must_use]
 #[track_caller]
-pub fn map<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn map<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Asyncify<Projection>: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Asyncify<Projection>: Injectable<NewType, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     map_with_description(Descr::map(), proj)
 }
@@ -35,16 +33,14 @@ where
 /// The asynchronous version of [`map`].
 #[must_use]
 #[track_caller]
-pub fn map_async<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn map_async<'a, Projection, Output, NewType, Args, Descr>(
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Projection: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Projection: Injectable<NewType, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     map_async_with_description(Descr::map_async(), proj)
 }
@@ -52,17 +48,15 @@ where
 /// [`map`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn map_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn map_with_description<'a, Projection, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Asyncify<Projection>: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Asyncify<Projection>: Injectable<NewType, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     map_async_with_description(description, Asyncify(proj))
 }
@@ -70,23 +64,21 @@ where
 /// [`map_async`] with a custom description.
 #[must_use]
 #[track_caller]
-pub fn map_async_with_description<'a, Projection, Input, Output, NewType, Args, Descr>(
+pub fn map_async_with_description<'a, Projection, Output, NewType, Args, Descr>(
     description: Descr,
     proj: Projection,
-) -> Handler<'a, Input, Output, Descr>
+) -> Handler<'a, Output, Descr>
 where
-    Input: Clone,
-    Projection: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-    Input: Insert<NewType> + Send + 'a,
+    Projection: Injectable<NewType, Args> + Send + Sync + 'a,
     Output: 'a,
     Descr: HandlerDescription,
-    NewType: Send + 'static,
+    NewType: Send + Sync + 'static,
 {
     let proj = Arc::new(proj);
 
     from_fn_with_description(
         description,
-        move |container: Input, cont| {
+        move |container, cont| {
             let proj = Arc::clone(&proj);
 
             async move {

--- a/src/handler/methods.rs
+++ b/src/handler/methods.rs
@@ -36,7 +36,7 @@ where
     where
         Input: Insert<NewType> + Clone,
         Asyncify<Proj>: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-        NewType: Send,
+        NewType: Send + 'static,
     {
         self.chain(crate::filter_map(proj))
     }
@@ -51,7 +51,7 @@ where
     where
         Input: Insert<NewType> + Clone,
         Proj: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-        NewType: Send,
+        NewType: Send + 'static,
     {
         self.chain(crate::filter_map_async(proj))
     }
@@ -63,7 +63,7 @@ where
     where
         Input: Insert<NewType> + Clone,
         Asyncify<Proj>: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-        NewType: Send,
+        NewType: Send + 'static,
     {
         self.chain(crate::map(proj))
     }
@@ -75,7 +75,7 @@ where
     where
         Input: Insert<NewType> + Clone,
         Proj: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-        NewType: Send,
+        NewType: Send + 'static,
     {
         self.chain(crate::map_async(proj))
     }
@@ -106,6 +106,7 @@ where
     pub fn endpoint<F, FnArgs>(self, f: F) -> Handler<'a, Input, Output, Descr>
     where
         F: Injectable<Input, Output, FnArgs> + Send + Sync + 'a,
+        Output: 'static,
     {
         self.chain(crate::endpoint(f))
     }

--- a/src/handler/methods.rs
+++ b/src/handler/methods.rs
@@ -1,20 +1,19 @@
 use crate::{
-    di::{Asyncify, Injectable, Insert},
+    di::{Asyncify, Injectable},
     Handler, HandlerDescription,
 };
 
-impl<'a, Input, Output, Descr> Handler<'a, Input, Output, Descr>
+impl<'a, Output, Descr> Handler<'a, Output, Descr>
 where
-    Input: Send + 'a,
     Output: 'a,
     Descr: HandlerDescription,
 {
     /// Chain this handler with the filter predicate `pred`.
     #[must_use]
     #[track_caller]
-    pub fn filter<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Input, Output, Descr>
+    pub fn filter<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Output, Descr>
     where
-        Asyncify<Pred>: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
+        Asyncify<Pred>: Injectable<bool, FnArgs> + Send + Sync + 'a,
     {
         self.chain(crate::filter(pred))
     }
@@ -22,9 +21,9 @@ where
     /// Chain this handler with the async filter predicate `pred`.
     #[must_use]
     #[track_caller]
-    pub fn filter_async<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Input, Output, Descr>
+    pub fn filter_async<Pred, FnArgs>(self, pred: Pred) -> Handler<'a, Output, Descr>
     where
-        Pred: Injectable<Input, bool, FnArgs> + Send + Sync + 'a,
+        Pred: Injectable<bool, FnArgs> + Send + Sync + 'a,
     {
         self.chain(crate::filter_async(pred))
     }
@@ -32,11 +31,10 @@ where
     /// Chain this handler with the filter projection `proj`.
     #[must_use]
     #[track_caller]
-    pub fn filter_map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Input, Output, Descr>
+    pub fn filter_map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Input: Insert<NewType> + Clone,
-        Asyncify<Proj>: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-        NewType: Send + 'static,
+        Asyncify<Proj>: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+        NewType: Send + Sync + 'static,
     {
         self.chain(crate::filter_map(proj))
     }
@@ -44,14 +42,10 @@ where
     /// Chain this handler with the async filter projection `proj`.
     #[must_use]
     #[track_caller]
-    pub fn filter_map_async<Proj, NewType, Args>(
-        self,
-        proj: Proj,
-    ) -> Handler<'a, Input, Output, Descr>
+    pub fn filter_map_async<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Input: Insert<NewType> + Clone,
-        Proj: Injectable<Input, Option<NewType>, Args> + Send + Sync + 'a,
-        NewType: Send + 'static,
+        Proj: Injectable<Option<NewType>, Args> + Send + Sync + 'a,
+        NewType: Send + Sync + 'static,
     {
         self.chain(crate::filter_map_async(proj))
     }
@@ -59,11 +53,10 @@ where
     /// Chain this handler with the map projection `proj`.
     #[must_use]
     #[track_caller]
-    pub fn map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Input, Output, Descr>
+    pub fn map<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Input: Insert<NewType> + Clone,
-        Asyncify<Proj>: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-        NewType: Send + 'static,
+        Asyncify<Proj>: Injectable<NewType, Args> + Send + Sync + 'a,
+        NewType: Send + Sync + 'static,
     {
         self.chain(crate::map(proj))
     }
@@ -71,11 +64,10 @@ where
     /// Chain this handler with the async map projection `proj`.
     #[must_use]
     #[track_caller]
-    pub fn map_async<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Input, Output, Descr>
+    pub fn map_async<Proj, NewType, Args>(self, proj: Proj) -> Handler<'a, Output, Descr>
     where
-        Input: Insert<NewType> + Clone,
-        Proj: Injectable<Input, NewType, Args> + Send + Sync + 'a,
-        NewType: Send + 'static,
+        Proj: Injectable<NewType, Args> + Send + Sync + 'a,
+        NewType: Send + Sync + 'static,
     {
         self.chain(crate::map_async(proj))
     }
@@ -83,9 +75,9 @@ where
     /// Chain this handler with the inspection function `f`.
     #[must_use]
     #[track_caller]
-    pub fn inspect<F, Args>(self, f: F) -> Handler<'a, Input, Output, Descr>
+    pub fn inspect<F, Args>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        Asyncify<F>: Injectable<Input, (), Args> + Send + Sync + 'a,
+        Asyncify<F>: Injectable<(), Args> + Send + Sync + 'a,
     {
         self.chain(crate::inspect(f))
     }
@@ -93,9 +85,9 @@ where
     /// Chain this handler with the async inspection function `f`.
     #[must_use]
     #[track_caller]
-    pub fn inspect_async<F, Args>(self, f: F) -> Handler<'a, Input, Output, Descr>
+    pub fn inspect_async<F, Args>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        F: Injectable<Input, (), Args> + Send + Sync + 'a,
+        F: Injectable<(), Args> + Send + Sync + 'a,
     {
         self.chain(crate::inspect_async(f))
     }
@@ -103,9 +95,9 @@ where
     /// Chain this handler with the endpoint handler `f`.
     #[must_use]
     #[track_caller]
-    pub fn endpoint<F, FnArgs>(self, f: F) -> Handler<'a, Input, Output, Descr>
+    pub fn endpoint<F, FnArgs>(self, f: F) -> Handler<'a, Output, Descr>
     where
-        F: Injectable<Input, Output, FnArgs> + Send + Sync + 'a,
+        F: Injectable<Output, FnArgs> + Send + Sync + 'a,
         Output: 'static,
     {
         self.chain(crate::endpoint(f))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! ```
 //! use dptree::prelude::*;
 //!
-//! type WebHandler = Endpoint<'static, DependencyMap, String>;
+//! type WebHandler = Endpoint<'static, String>;
 //!
 //! #[rustfmt::skip]
 //! #[tokio::main]
@@ -105,7 +105,7 @@ pub use handler::*;
 ///     Add(i32, i32),
 /// }
 ///
-/// let h: crate::Handler<_, _> = dptree::entry()
+/// let h: Handler<_> = dptree::entry()
 ///     .branch(dptree::case![Command::Meow].endpoint(|| async move { format!("Meow!") }))
 ///     .branch(
 ///         dptree::case![Command::Add(x, y)]
@@ -172,7 +172,7 @@ mod tests {
     #[tokio::test]
     async fn handler_empty_variant() {
         let input = State::A;
-        let h: crate::Handler<_, _> = case![State::A].endpoint(|| async move { 123 });
+        let h: crate::Handler<_> = case![State::A].endpoint(|| async move { 123 });
 
         assert_eq!(h.dispatch(crate::deps![input]).await, ControlFlow::Break(123));
         assert!(matches!(h.dispatch(crate::deps![State::Other]).await, ControlFlow::Continue(_)));
@@ -181,7 +181,7 @@ mod tests {
     #[tokio::test]
     async fn handler_single_fn_variant() {
         let input = State::B(42);
-        let h: crate::Handler<_, _> = case![State::B(x)].endpoint(|x: i32| async move {
+        let h: crate::Handler<_> = case![State::B(x)].endpoint(|x: i32| async move {
             assert_eq!(x, 42);
             123
         });
@@ -193,7 +193,7 @@ mod tests {
     #[tokio::test]
     async fn handler_single_fn_variant_trailing_comma() {
         let input = State::B(42);
-        let h: crate::Handler<_, _> = case![State::B(x,)].endpoint(|(x,): (i32,)| async move {
+        let h: crate::Handler<_> = case![State::B(x,)].endpoint(|(x,): (i32,)| async move {
             assert_eq!(x, 42);
             123
         });
@@ -205,7 +205,7 @@ mod tests {
     #[tokio::test]
     async fn handler_fn_variant() {
         let input = State::C(42, "abc");
-        let h: crate::Handler<_, _> =
+        let h: crate::Handler<_> =
             case![State::C(x, y)].endpoint(|(x, str): (i32, &'static str)| async move {
                 assert_eq!(x, 42);
                 assert_eq!(str, "abc");
@@ -219,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn handler_single_struct_variant() {
         let input = State::D { foo: 42 };
-        let h: crate::Handler<_, _> = case![State::D { foo }].endpoint(|x: i32| async move {
+        let h: crate::Handler<_> = case![State::D { foo }].endpoint(|x: i32| async move {
             assert_eq!(x, 42);
             123
         });
@@ -232,7 +232,7 @@ mod tests {
     async fn handler_single_struct_variant_trailing_comma() {
         let input = State::D { foo: 42 };
         #[rustfmt::skip] // rustfmt removes the trailing comma from `State::D { foo, }`, but it plays a vital role in this test.
-        let h: crate::Handler<_, _> = case![State::D { foo, }].endpoint(|(x,): (i32,)| async move {
+        let h: crate::Handler<_> = case![State::D { foo, }].endpoint(|(x,): (i32,)| async move {
             assert_eq!(x, 42);
             123
         });
@@ -244,7 +244,7 @@ mod tests {
     #[tokio::test]
     async fn handler_struct_variant() {
         let input = State::E { foo: 42, bar: "abc" };
-        let h: crate::Handler<_, _> =
+        let h: crate::Handler<_> =
             case![State::E { foo, bar }].endpoint(|(x, str): (i32, &'static str)| async move {
                 assert_eq!(x, 42);
                 assert_eq!(str, "abc");


### PR DESCRIPTION
This PR introduces the `dptree::type_check` function that makes sure that all types required by `Handler` are present in `DependencyMap`. In order to decide which types are required by `Handler`, we use (run-time) type inference.

While the changes in this PR are formally **BC**, little or no intervention is required by a `dptree` user to update their code. The main addition is `dptree::type_check`, which is designed to be called _before_ executing a handler; for example, in `teloxide`, we could invoke `dptree::type_check` at some point while building `Dispatcher`. Given that, practically everywhere, a dispatch tree is constructed at a program startup, our type checking should be almost the same as static type checking (modulo different type mismatch messages).

See more information in `CHANGELOG.md`.
