### PR TITLE
Support up to 12 params in the handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## unreleased
 
 ### Added
-- feature `di-params-15` which increases the upper limit of supported arguments in handlers from 9 to 15
+- The handlers now can accept up to 12 parameters instead of 9
 
 ## 0.3.0 - 2022-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## unreleased
 
 ### Added
-- The handlers now can accept up to 12 parameters instead of 9
+
+ - The handlers now can accept up to 12 parameters instead of 9.
 
 ## 0.3.0 - 2022-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Added
+- feature `di-params-15` which increases the upper limit of supported arguments in handlers from 9 to 15
+
 ## 0.3.0 - 2022-07-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+di-params-15 = []
+
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-di-params-15 = []
-
 [dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 

--- a/src/di.rs
+++ b/src/di.rs
@@ -189,8 +189,7 @@ where
 ///
 /// 1. For each function parameter of type `T`, `Input` must satisfy
 /// `DependencySupplier<T>`.
-/// 2. The function must be of 0-9 arguments. With the `di-params-15` feature
-///    the upper limit is increased up to the 15
+/// 2. The function must be of 0-12 arguments.
 /// 3. The function must return [`Future`].
 pub trait Injectable<Input, Output, FnArgs> {
     fn inject<'a>(&'a self, container: &'a Input) -> CompiledFn<'a, Output>;
@@ -255,18 +254,9 @@ impl_into_di!(T1, T2, T3, T4, T5, T6);
 impl_into_di!(T1, T2, T3, T4, T5, T6, T7);
 impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8);
 impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
-
-#[cfg(feature = "di-params-15")]
-mod di_params_15 {
-    use super::*;
-
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
-    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
-}
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
 
 /// Constructs [`DependencyMap`] with a list of dependencies.
 ///

--- a/src/di.rs
+++ b/src/di.rs
@@ -258,6 +258,8 @@ impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
 
 #[cfg(feature = "di-params-15")]
 mod di_params_15 {
+    use super::*;
+
     impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
     impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
     impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);

--- a/src/di.rs
+++ b/src/di.rs
@@ -189,7 +189,8 @@ where
 ///
 /// 1. For each function parameter of type `T`, `Input` must satisfy
 /// `DependencySupplier<T>`.
-/// 2. The function must be of 0-9 arguments.
+/// 2. The function must be of 0-9 arguments. With the `di-params-15` feature
+///    the upper limit is increased up to the 15
 /// 3. The function must return [`Future`].
 pub trait Injectable<Input, Output, FnArgs> {
     fn inject<'a>(&'a self, container: &'a Input) -> CompiledFn<'a, Output>;
@@ -245,15 +246,25 @@ macro_rules! impl_into_di {
 }
 
 impl_into_di!();
-impl_into_di!(A);
-impl_into_di!(A, B);
-impl_into_di!(A, B, C);
-impl_into_di!(A, B, C, D);
-impl_into_di!(A, B, C, D, E);
-impl_into_di!(A, B, C, D, E, F);
-impl_into_di!(A, B, C, D, E, F, G);
-impl_into_di!(A, B, C, D, E, F, G, H);
-impl_into_di!(A, B, C, D, E, F, G, H, I);
+impl_into_di!(T1);
+impl_into_di!(T1, T2);
+impl_into_di!(T1, T2, T3);
+impl_into_di!(T1, T2, T3, T4);
+impl_into_di!(T1, T2, T3, T4, T5);
+impl_into_di!(T1, T2, T3, T4, T5, T6);
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7);
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+
+#[cfg(feature = "di-params-15")]
+mod di_params_15 {
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
+    impl_into_di!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+}
 
 /// Constructs [`DependencyMap`] with a list of dependencies.
 ///


### PR DESCRIPTION
Inspired by [this message](https://t.me/teloxide/20585)

I know, that many parameters in the handler functions can be the sign of the bad code. But sometimes there is no other choices. 

Personally I met the need for increasing the limit of the parameters too when I worked on my Teloxide bot. I used `filter_map` extensively, so ran out of available "capacity" of the parameters. So, I need to use "bundle-structs" to pack my params to make them available in my code:
```
pub async fn start(
    teloxide_standard_bundle: TeloxideStandardBundle,
    dialogue: GlobalDialogue,

    users_service: DynUsersService,
    settings_service: DynSettingsService,
    i18n_service: DynI18nService,
) -> HandlerResult {
...
}

pub struct TeloxideStandardBundle {
    pub bot: Bot,
    pub user: User,
    pub language_bundle: LanguageBundle,
}
```

It's annoying sometimes, but acceptable to me, but it would be really nice to have "an extended capacity".

I put this feature behind the flag "di-params-15". Maybe not the best naming, though :)