### PR TITLE
Improved case macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - The `Handler::sig` function.
  - The `di::Injectable::input_types` associated function [**BC**].
  - The `DependencyMap::try_get` method ([PR #29](https://github.com/teloxide/dptree/pull/29)).
+ - More functionality to `case!` macro. Now it can inject almost anything that rust pattern matching can interpret.
 
 ### Changed
 


### PR DESCRIPTION
Inspired by [this](https://t.me/teloxide/24107) message.

Although the code for `case!` was fully rewritten, there are no breaking changes!

The goal was to make the `case!` pattern matching the same as the rust pattern matching, and I think it's pretty close for `dptree` purposes!

Sad that it's almost impossible to infer the type of `None`, but it's fine

I think the tests cover all of the new use cases 